### PR TITLE
feat: oc add accepts multiple packages in one invocation

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/emilkloeden/oc/internal/opam"
 	"github.com/emilkloeden/oc/internal/project"
@@ -12,14 +13,13 @@ import (
 var addDev bool
 
 var addCmd = &cobra.Command{
-	Use:   "add <package> [constraint]",
-	Short: "Add a dependency to the project",
-	Args:  cobra.RangeArgs(1, 2),
+	Use:   "add <package> [constraint] [<package> [constraint]]...",
+	Short: "Add one or more dependencies to the project",
+	Args:  cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pkg := args[0]
-		constraint := "*"
-		if len(args) == 2 {
-			constraint = args[1]
+		deps, err := parseAddArgs(args)
+		if err != nil {
+			return err
 		}
 
 		dir, err := projectRoot()
@@ -32,10 +32,12 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		if addDev {
-			cfg.DevDependencies[pkg] = constraint
-		} else {
-			cfg.Dependencies[pkg] = constraint
+		for _, d := range deps {
+			if addDev {
+				cfg.DevDependencies[d.Name] = d.Constraint
+			} else {
+				cfg.Dependencies[d.Name] = d.Constraint
+			}
 		}
 
 		if err := project.SaveConfig(dir, cfg); err != nil {
@@ -50,9 +52,43 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		fmt.Printf("Added %q to dependencies.\n", pkg)
+		for _, d := range deps {
+			fmt.Printf("Added %q to dependencies.\n", d.Name)
+		}
 		return nil
 	},
+}
+
+// isConstraint reports whether an argument looks like a version constraint rather than
+// a package name. Constraints start with >=, <=, =, ~, or *.
+func isConstraint(s string) bool {
+	return strings.HasPrefix(s, ">=") ||
+		strings.HasPrefix(s, "<=") ||
+		strings.HasPrefix(s, "=") ||
+		strings.HasPrefix(s, "~") ||
+		s == "*"
+}
+
+// parseAddArgs parses the positional arguments for "oc add" into a slice of Dep values.
+// The rule is: an argument that looks like a constraint (starts with >=, <=, =, ~, or is *)
+// is attached to the preceding package. Otherwise it starts a new package entry.
+func parseAddArgs(args []string) ([]project.Dep, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("at least one package name is required")
+	}
+
+	var deps []project.Dep
+	for _, arg := range args {
+		if isConstraint(arg) {
+			if len(deps) == 0 {
+				return nil, fmt.Errorf("constraint %q given before any package name", arg)
+			}
+			deps[len(deps)-1].Constraint = arg
+		} else {
+			deps = append(deps, project.Dep{Name: arg, Constraint: "*"})
+		}
+	}
+	return deps, nil
 }
 
 func init() {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,82 @@
+package cmd_test
+
+import (
+	"testing"
+
+	"github.com/emilkloeden/oc/cmd"
+	"github.com/emilkloeden/oc/internal/project"
+)
+
+func TestParseAddArgs_SinglePackage(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []project.Dep{{Name: "pkg1", Constraint: "*"}}
+	assertDeps(t, deps, want)
+}
+
+func TestParseAddArgs_SinglePackageWithConstraint(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg1", ">=1.0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []project.Dep{{Name: "pkg1", Constraint: ">=1.0"}}
+	assertDeps(t, deps, want)
+}
+
+func TestParseAddArgs_TwoPackagesNoConstraints(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg1", "pkg2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []project.Dep{
+		{Name: "pkg1", Constraint: "*"},
+		{Name: "pkg2", Constraint: "*"},
+	}
+	assertDeps(t, deps, want)
+}
+
+func TestParseAddArgs_PackageWithConstraintThenPackage(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg1", ">=1.0", "pkg2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []project.Dep{
+		{Name: "pkg1", Constraint: ">=1.0"},
+		{Name: "pkg2", Constraint: "*"},
+	}
+	assertDeps(t, deps, want)
+}
+
+func TestParseAddArgs_TwoPackagesEachWithConstraint(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg1", ">=1.0", "pkg2", "<=2.0"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []project.Dep{
+		{Name: "pkg1", Constraint: ">=1.0"},
+		{Name: "pkg2", Constraint: "<=2.0"},
+	}
+	assertDeps(t, deps, want)
+}
+
+func TestParseAddArgs_Empty_ReturnsError(t *testing.T) {
+	_, err := cmd.ParseAddArgs([]string{})
+	if err == nil {
+		t.Fatal("expected error for empty args, got nil")
+	}
+}
+
+// assertDeps checks that got matches want (order-sensitive).
+func assertDeps(t *testing.T, got, want []project.Dep) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("len(deps) = %d, want %d; got %v", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i].Name != w.Name || got[i].Constraint != w.Constraint {
+			t.Errorf("deps[%d] = %+v, want %+v", i, got[i], w)
+		}
+	}
+}

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -10,3 +10,4 @@ import (
 var PrintEnvInfo = func(w io.Writer, lock *project.Lock) { printEnvInfo(w, lock) }
 var FindProjectRoot = findProjectRoot
 var BuildRunArgs = buildRunArgs
+var ParseAddArgs = parseAddArgs

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -34,6 +34,12 @@ type Package struct {
 	Version string `toml:"version"`
 }
 
+// Dep represents a package name and its version constraint as parsed from CLI arguments.
+type Dep struct {
+	Name       string
+	Constraint string
+}
+
 type Lock struct {
 	OCaml      OCamlMeta `toml:"ocaml"`
 	SwitchPath string    `toml:"switch_path,omitempty"`


### PR DESCRIPTION
## Summary

- `oc add pkg1 pkg2 pkg3` now adds all three packages with no constraints
- `oc add pkg1 ">=1.0" pkg2` adds pkg1 with `>=1.0` and pkg2 unconstrained
- `oc add pkg1 ">=1.0"` (existing single-package-with-constraint behaviour) is preserved
- A sync against opam runs **once** after all packages are written to `oc.toml`

## How it works

An argument is treated as a constraint if it starts with `>=`, `<=`, `=`, `~`, or equals `*`; otherwise it is a new package name. This is implemented in `parseAddArgs` (pure function, no subprocess calls).

A new `project.Dep` struct (`Name string`, `Constraint string`) carries the parsed result. `ParseAddArgs` is exported via `cmd/export_test.go` for white-box unit testing without invoking cobra or opam.

## Test plan

- [x] `TestParseAddArgs_SinglePackage` — `["pkg1"]` → `[{pkg1, *}]`
- [x] `TestParseAddArgs_SinglePackageWithConstraint` — `["pkg1", ">=1.0"]` → `[{pkg1, >=1.0}]`
- [x] `TestParseAddArgs_TwoPackagesNoConstraints` — `["pkg1", "pkg2"]` → `[{pkg1, *}, {pkg2, *}]`
- [x] `TestParseAddArgs_PackageWithConstraintThenPackage` — `["pkg1", ">=1.0", "pkg2"]` → `[{pkg1, >=1.0}, {pkg2, *}]`
- [x] `TestParseAddArgs_TwoPackagesEachWithConstraint` — `["pkg1", ">=1.0", "pkg2", "<=2.0"]` → both constrained
- [x] `TestParseAddArgs_Empty_ReturnsError` — empty args returns an error
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` — 0 issues

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)