### PR TITLE
fix: create new switch when OCaml version changes

### DIFF
--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -77,9 +77,11 @@ func EnsureWith(dir string, cfg *project.Config, runner OpamRunner) error {
 	if err != nil {
 		return err
 	}
-	if lock.OCaml.Version == "" {
-		lock.OCaml.Version = cfg.OCaml.Version
+	// Detect OCaml version change — stale switch path must be discarded.
+	if lock.OCaml.Version != "" && lock.OCaml.Version != cfg.OCaml.Version {
+		lock.SwitchPath = ""
 	}
+	lock.OCaml.Version = cfg.OCaml.Version
 
 	// Use the stored switch path if present and the switch still exists there.
 	// This keeps the path stable even after the lock is populated with packages

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -197,3 +197,30 @@ func TestEnsureWith_PropagatesCreateError(t *testing.T) {
 		t.Fatal("expected error when CreateSwitch fails")
 	}
 }
+
+func TestEnsureWith_NewSwitchOnOCamlVersionChange(t *testing.T) {
+	dir := t.TempDir()
+	runner := &mockRunner{switches: map[string]bool{}}
+
+	// First call with 5.2.0
+	if err := sync.EnsureWith(dir, cfg("5.2.0"), runner); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.createCalled) != 1 {
+		t.Fatalf("expected 1 CreateSwitch call, got %d", len(runner.createCalled))
+	}
+	path1 := runner.createCalled[0]
+
+	// Second call with a different OCaml version
+	if err := sync.EnsureWith(dir, cfg("5.3.0"), runner); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.createCalled) != 2 {
+		t.Fatalf("expected 2 CreateSwitch calls, got %d", len(runner.createCalled))
+	}
+	path2 := runner.createCalled[1]
+
+	if path1 == path2 {
+		t.Error("expected different switch paths for different OCaml versions")
+	}
+}


### PR DESCRIPTION
## Summary

- `EnsureWith` previously reused `lock.SwitchPath` even when `cfg.OCaml.Version` differed from the version recorded in the lock, causing opam to fail with a version conflict.
- When a version change is detected (`lock.OCaml.Version` is non-empty and differs from `cfg.OCaml.Version`), `lock.SwitchPath` is now cleared before the switch-path resolution logic runs, causing the content-addressed hash to produce a fresh switch directory for the new version.
- The old switch is left in the cache (not deleted) — it is simply no longer referenced.

## Test plan

- [ ] `TestEnsureWith_NewSwitchOnOCamlVersionChange` — new test that calls `EnsureWith` twice with different OCaml versions and asserts two distinct `CreateSwitch` calls with different paths.
- [ ] All existing `TestEnsureWith_*` tests continue to pass (reuse behaviour unchanged when version is the same).
- [ ] `go test ./...` — clean.
- [ ] `golangci-lint run ./...` — 0 issues.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)