### PR TITLE
fix: guard against missing or outdated opam with a helpful error

### DIFF
--- a/internal/opam/opam_version_test.go
+++ b/internal/opam/opam_version_test.go
@@ -1,0 +1,58 @@
+package opam_test
+
+import (
+	"testing"
+
+	"github.com/emilkloeden/oc/internal/opam"
+)
+
+func TestParseOpamVersion_Valid(t *testing.T) {
+	major, minor, err := opam.ParseOpamVersion("2.1.6")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if major != 2 || minor != 1 {
+		t.Errorf("expected 2.1, got %d.%d", major, minor)
+	}
+}
+
+func TestParseOpamVersion_Short(t *testing.T) {
+	major, minor, err := opam.ParseOpamVersion("2.1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if major != 2 || minor != 1 {
+		t.Errorf("expected 2.1, got %d.%d", major, minor)
+	}
+}
+
+func TestParseOpamVersion_Invalid(t *testing.T) {
+	_, _, err := opam.ParseOpamVersion("notaversion")
+	if err == nil {
+		t.Fatal("expected error for invalid version string, got nil")
+	}
+}
+
+func TestOpamVersionSatisfied_ExactMinimum(t *testing.T) {
+	if !opam.OpamVersionSatisfied(2, 1) {
+		t.Error("2.1 should satisfy the minimum requirement")
+	}
+}
+
+func TestOpamVersionSatisfied_NewerMajor(t *testing.T) {
+	if !opam.OpamVersionSatisfied(3, 0) {
+		t.Error("3.0 should satisfy the minimum requirement")
+	}
+}
+
+func TestOpamVersionSatisfied_TooOld(t *testing.T) {
+	if opam.OpamVersionSatisfied(2, 0) {
+		t.Error("2.0 should NOT satisfy the minimum requirement")
+	}
+}
+
+func TestOpamVersionSatisfied_OldMajor(t *testing.T) {
+	if opam.OpamVersionSatisfied(1, 9) {
+		t.Error("1.9 should NOT satisfy the minimum requirement")
+	}
+}

--- a/internal/opam/version.go
+++ b/internal/opam/version.go
@@ -1,0 +1,60 @@
+package opam
+
+import (
+	"fmt"
+	osexec "os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/emilkloeden/oc/internal/exec"
+)
+
+// ParseOpamVersion parses a version string like "2.1.6" or "2.1" into major
+// and minor integers. It returns an error if the string cannot be parsed.
+func ParseOpamVersion(s string) (major, minor int, err error) {
+	s = strings.TrimSpace(s)
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("cannot parse opam version %q: expected at least major.minor", s)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot parse opam version %q: %w", s, err)
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("cannot parse opam version %q: %w", s, err)
+	}
+	return major, minor, nil
+}
+
+// OpamVersionSatisfied returns true when major.minor meets the minimum
+// requirement of opam >= 2.1.
+func OpamVersionSatisfied(major, minor int) bool {
+	return major > 2 || (major == 2 && minor >= 1)
+}
+
+// CheckOpam verifies that opam is on PATH and is version 2.1 or later.
+// It returns a descriptive, actionable error if either check fails.
+func CheckOpam() error {
+	if _, err := osexec.LookPath("opam"); err != nil {
+		return fmt.Errorf("opam not found on PATH.\nInstall it from: https://opam.ocaml.org/doc/Install.html")
+	}
+
+	out, err := exec.Output("opam", []string{"--version"}, exec.Options{})
+	if err != nil {
+		return fmt.Errorf("could not determine opam version: %w", err)
+	}
+
+	version := strings.TrimSpace(out)
+	major, minor, err := ParseOpamVersion(version)
+	if err != nil {
+		return fmt.Errorf("could not parse opam version %q: %w", version, err)
+	}
+
+	if !OpamVersionSatisfied(major, minor) {
+		return fmt.Errorf("opam 2.1 or later is required (found %s).\nUpgrade: https://opam.ocaml.org/doc/Install.html", version)
+	}
+
+	return nil
+}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/emilkloeden/oc/internal/exec"
+	"github.com/emilkloeden/oc/internal/opam"
 	"github.com/emilkloeden/oc/internal/project"
 	swmgr "github.com/emilkloeden/oc/internal/switch"
 )
@@ -68,6 +69,9 @@ func (r *realRunner) ListInstalled(switchPath string) ([]project.Package, error)
 
 // Ensure is the public entry point using the real opam runner.
 func Ensure(dir string, cfg *project.Config) error {
+	if err := opam.CheckOpam(); err != nil {
+		return err
+	}
 	return EnsureWith(dir, cfg, &realRunner{})
 }
 


### PR DESCRIPTION
## Summary

- Adds `CheckOpam()` pre-flight check called at the top of `sync.Ensure()` — the single entry point for all commands that invoke opam
- Verifies opam is on PATH (via `os/exec.LookPath`) and is version 2.1 or later (via `opam --version`)
- Returns descriptive, actionable errors with install/upgrade URLs instead of raw subprocess failures
- Pure helper functions `ParseOpamVersion` and `OpamVersionSatisfied` are fully unit-tested without requiring opam installed

## Test plan

- [x] `TestParseOpamVersion_Valid` — parses "2.1.6" → major=2, minor=1
- [x] `TestParseOpamVersion_Short` — parses "2.1" → major=2, minor=1
- [x] `TestParseOpamVersion_Invalid` — returns error for "notaversion"
- [x] `TestOpamVersionSatisfied_ExactMinimum` — 2.1 → true
- [x] `TestOpamVersionSatisfied_NewerMajor` — 3.0 → true
- [x] `TestOpamVersionSatisfied_TooOld` — 2.0 → false
- [x] `TestOpamVersionSatisfied_OldMajor` — 1.9 → false
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)