### PR TITLE
fix: handle non-symlink .ocaml in EnsureSymlink

### DIFF
--- a/internal/switch/switch.go
+++ b/internal/switch/switch.go
@@ -39,7 +39,10 @@ func EnsureSymlink(projectDir, target string) error {
 	info, err := os.Lstat(link)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return os.Symlink(target, link)
+			if err := os.Symlink(target, link); err != nil {
+				return fmt.Errorf("create symlink: %w", err)
+			}
+			return nil
 		}
 		return fmt.Errorf("stat .ocaml: %w", err)
 	}

--- a/internal/switch/switch.go
+++ b/internal/switch/switch.go
@@ -36,14 +36,39 @@ func CachePath(lock *project.Lock) string {
 func EnsureSymlink(projectDir, target string) error {
 	link := filepath.Join(projectDir, ".ocaml")
 
-	if existing, err := os.Readlink(link); err == nil {
-		if existing == target {
-			return nil
+	info, err := os.Lstat(link)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return os.Symlink(target, link)
 		}
-		if err := os.Remove(link); err != nil {
-			return fmt.Errorf("remove stale symlink: %w", err)
-		}
+		return fmt.Errorf("stat .ocaml: %w", err)
 	}
 
+	if info.Mode()&os.ModeSymlink == 0 {
+		return fmt.Errorf(".ocaml exists as a %s; remove it manually to allow oc to manage the switch symlink",
+			fileTypeDescription(info.Mode()))
+	}
+
+	existing, err := os.Readlink(link)
+	if err != nil {
+		return fmt.Errorf("readlink .ocaml: %w", err)
+	}
+	if existing == target {
+		return nil
+	}
+	if err := os.Remove(link); err != nil {
+		return fmt.Errorf("remove stale symlink: %w", err)
+	}
 	return os.Symlink(target, link)
+}
+
+func fileTypeDescription(mode os.FileMode) string {
+	switch {
+	case mode.IsDir():
+		return "directory"
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	default:
+		return "regular file"
+	}
 }

--- a/internal/switch/switch_test.go
+++ b/internal/switch/switch_test.go
@@ -3,6 +3,7 @@ package swmgr_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	sw "github.com/emilkloeden/oc/internal/switch"
@@ -109,5 +110,39 @@ func TestEnsureSymlink_UpdatesStaleLink(t *testing.T) {
 	resolved, _ := os.Readlink(filepath.Join(projectDir, ".ocaml"))
 	if resolved != newTarget {
 		t.Errorf("symlink not updated: got %q want %q", resolved, newTarget)
+	}
+}
+
+func TestEnsureSymlink_RegularFileReturnsError(t *testing.T) {
+	projectDir := t.TempDir()
+	link := filepath.Join(projectDir, ".ocaml")
+	// Create a regular file (not a symlink) at .ocaml
+	if err := os.WriteFile(link, []byte("not a symlink"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	err := sw.EnsureSymlink(projectDir, target)
+	if err == nil {
+		t.Fatal("expected error when .ocaml is a regular file, got nil")
+	}
+	if !strings.Contains(err.Error(), "remove it manually") {
+		t.Errorf("error should mention 'remove it manually' to guide the user; got: %v", err)
+	}
+}
+
+func TestEnsureSymlink_DirectoryReturnsError(t *testing.T) {
+	projectDir := t.TempDir()
+	link := filepath.Join(projectDir, ".ocaml")
+	// Create a directory at .ocaml
+	if err := os.MkdirAll(link, 0755); err != nil {
+		t.Fatal(err)
+	}
+	target := t.TempDir()
+	err := sw.EnsureSymlink(projectDir, target)
+	if err == nil {
+		t.Fatal("expected error when .ocaml is a directory, got nil")
+	}
+	if !strings.Contains(err.Error(), "remove it manually") {
+		t.Errorf("error should mention 'remove it manually' to guide the user; got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Use `os.Lstat` before `os.Readlink` in `EnsureSymlink` to determine the type of filesystem entry at `.ocaml`
- Distinguish three cases: path absent (create symlink), existing symlink (update if stale), regular file or directory (return actionable error)
- The error message now tells the user exactly what to do: `.ocaml exists as a regular file; remove it manually to allow oc to manage the switch symlink`

## Test plan

- [ ] `TestEnsureSymlink_RegularFileReturnsError` — confirms error is returned and contains "remove it manually" when `.ocaml` is a regular file
- [ ] `TestEnsureSymlink_DirectoryReturnsError` — same check when `.ocaml` is a directory
- [ ] All pre-existing symlink tests (`CreatesLink`, `UpdatesStaleLink`) continue to pass
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` reports 0 issues

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)