### PR TITLE
fix: validate project name and rollback on oc new scaffold failure

### DIFF
--- a/cmd/new.go
+++ b/cmd/new.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/emilkloeden/oc/internal/dune"
@@ -12,6 +13,8 @@ import (
 	"github.com/emilkloeden/oc/internal/project"
 	"github.com/spf13/cobra"
 )
+
+var validProjectName = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
 
 var newLib bool
 
@@ -30,6 +33,10 @@ var newCmd = &cobra.Command{
 
 // RunNew creates a new project under parent/name. Extracted for testability.
 func RunNew(parent, name string, lib bool) error {
+	if !validProjectName.MatchString(name) {
+		return fmt.Errorf("invalid project name %q: must start with a letter and contain only letters, digits, and underscores", name)
+	}
+
 	dir := filepath.Join(parent, name)
 
 	if _, err := os.Stat(dir); err == nil {
@@ -38,6 +45,14 @@ func RunNew(parent, name string, lib bool) error {
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return err
 	}
+
+	// Clean up the created directory if any subsequent step fails.
+	success := false
+	defer func() {
+		if !success {
+			_ = os.RemoveAll(dir)
+		}
+	}()
 
 	maintainer := gitMaintainer()
 	authors := []string{"Your Name <you@example.com>"}
@@ -81,6 +96,7 @@ func RunNew(parent, name string, lib bool) error {
 	initGit(dir)
 
 	fmt.Printf("Created %q. Run:\n  cd %s\n  oc run\n", name, name)
+	success = true
 	return nil
 }
 

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -91,6 +91,54 @@ func TestNew_FailsIfDirExists(t *testing.T) {
 	}
 }
 
+func TestNew_InvalidNameReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	cases := []string{
+		"my project",  // space
+		"123abc",      // starts with digit
+		"my-project",  // hyphen
+		"my.project",  // dot
+		"my(project",  // parens
+		"",            // empty
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			err := cmd.RunNew(dir, name, false)
+			if err == nil {
+				t.Errorf("expected error for name %q, got nil", name)
+			}
+		})
+	}
+}
+
+func TestNew_ValidNameSucceeds(t *testing.T) {
+	cases := []string{
+		"myapp",
+		"my_app",
+		"MyApp",
+		"app123",
+		"a",
+	}
+	for _, name := range cases {
+		t.Run(name, func(t *testing.T) {
+			subDir := t.TempDir()
+			if err := cmd.RunNew(subDir, name, false); err != nil {
+				t.Errorf("unexpected error for name %q: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestNew_InvalidNameDoesNotCreateDir(t *testing.T) {
+	dir := t.TempDir()
+	name := "invalid name with spaces"
+	_ = cmd.RunNew(dir, name, false)
+	projectDir := filepath.Join(dir, name)
+	if _, err := os.Stat(projectDir); !os.IsNotExist(err) {
+		t.Errorf("expected no directory at %s after failed RunNew", projectDir)
+	}
+}
+
 func splitLines(s string) []string {
 	var lines []string
 	start := 0


### PR DESCRIPTION
## Summary

- **Issue #17**: Validates the project name at the start of `RunNew` using `regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)`. Names with spaces, hyphens, dots, parens, or starting with digits are rejected with a clear error message before any filesystem operations occur.
- **Issue #13**: Adds a deferred cleanup pattern (`success` flag + `os.RemoveAll`) so that if any scaffold step after `MkdirAll` fails, the partially-created directory is removed automatically.

## Test plan

- [ ] `TestNew_InvalidNameReturnsError` — verifies that `"my project"`, `"123abc"`, `"my-project"`, `"my.project"`, `"my(project"`, and `""` all return errors
- [ ] `TestNew_ValidNameSucceeds` — verifies that `"myapp"`, `"my_app"`, `"MyApp"`, `"app123"`, and `"a"` are all accepted
- [ ] `TestNew_InvalidNameDoesNotCreateDir` — verifies that a failed `RunNew` (due to name validation) leaves no directory on disk
- [ ] All pre-existing `TestNew_*` tests continue to pass
- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` reports 0 issues

Closes #13
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)