### PR TITLE
fix: write oc.lock atomically to prevent torn writes

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -105,10 +105,22 @@ func LoadLock(dir string) (*Lock, error) {
 
 func SaveLock(dir string, lock *Lock) error {
 	path := filepath.Join(dir, lockFile)
-	f, err := os.Create(path)
+
+	tmp, err := os.CreateTemp(dir, ".oc.lock.*.tmp")
 	if err != nil {
 		return err
 	}
-	defer func() { _ = f.Close() }()
-	return toml.NewEncoder(f).Encode(lock)
+	tmpPath := tmp.Name()
+
+	if err := toml.NewEncoder(tmp).Encode(lock); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,8 +1,11 @@
 package project_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 
 	"github.com/emilkloeden/oc/internal/project"
@@ -144,6 +147,66 @@ func TestLoadLock_Missing(t *testing.T) {
 	}
 	if len(lock.Packages) != 0 {
 		t.Errorf("expected empty packages, got %v", lock.Packages)
+	}
+}
+
+func TestLoadLock_CorruptedFile(t *testing.T) {
+	dir := t.TempDir()
+	// Write a file that is present but contains invalid TOML
+	if err := os.WriteFile(filepath.Join(dir, "oc.lock"), []byte("NOT VALID TOML ][[["), 0644); err != nil {
+		t.Fatal(err)
+	}
+	lock, err := project.LoadLock(dir)
+	if err == nil {
+		t.Fatal("expected error for corrupted oc.lock, got nil")
+	}
+	if lock != nil {
+		t.Errorf("expected nil lock on error, got %+v", lock)
+	}
+}
+
+func TestSaveLock_NoTempFilesLeftOnSuccess(t *testing.T) {
+	dir := t.TempDir()
+	lock := &project.Lock{OCaml: project.OCamlMeta{Version: "5.2.0"}}
+	if err := project.SaveLock(dir, lock); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if strings.HasPrefix(e.Name(), ".oc.lock.") && strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind after SaveLock: %s", e.Name())
+		}
+	}
+}
+
+func TestSaveLock_ConcurrentWritesProduceValidFile(t *testing.T) {
+	dir := t.TempDir()
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer wg.Done()
+			lock := &project.Lock{
+				OCaml:      project.OCamlMeta{Version: "5.2.0"},
+				SwitchPath: fmt.Sprintf("/path/to/switch/%d", i),
+				Packages:   []project.Package{{Name: "pkg", Version: fmt.Sprintf("1.0.%d", i)}},
+			}
+			_ = project.SaveLock(dir, lock)
+		}()
+	}
+	wg.Wait()
+
+	_, err := project.LoadLock(dir)
+	if err != nil {
+		t.Errorf("after concurrent SaveLock, oc.lock is not parseable: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replaces `os.Create` with `os.CreateTemp` + `os.Rename` in `SaveLock` so the lock file is never partially visible to concurrent readers
- On POSIX systems (macOS and Linux), `os.Rename` within the same directory is atomic, guaranteeing readers always see a complete file
- Adds two new tests: `TestSaveLock_NoTempFilesLeftOnSuccess` (verifies cleanup) and `TestSaveLock_ConcurrentWritesProduceValidFile` (verifies the file remains parseable after 50 concurrent writers)

Closes #14

## Test plan

- [ ] `go test ./...` passes
- [ ] `golangci-lint run ./...` reports 0 issues
- [ ] `TestSaveLock_NoTempFilesLeftOnSuccess` confirms no `.oc.lock.*.tmp` files are left behind after a successful write
- [ ] `TestSaveLock_ConcurrentWritesProduceValidFile` confirms the lock file is parseable after 50 concurrent `SaveLock` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)