### PR TITLE
fix: propagate errors in build, run, and remove commands

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -17,24 +17,31 @@ var buildCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		cfg, err := project.LoadConfig(dir)
-		if err != nil {
-			return err
-		}
-
-		if err := sync.Ensure(dir, cfg); err != nil {
-			return err
-		}
-
-		lock, _ := project.LoadLock(dir)
-		switchPath := lock.SwitchPath
-
-		fmt.Println("Building...")
-		return exec.Run("opam", []string{
-			"exec", "--switch", switchPath, "--", "dune", "build",
-		}, exec.Options{Dir: dir})
+		return runBuild(dir)
 	},
+}
+
+// runBuild performs the build for the given project directory.
+func runBuild(dir string) error {
+	cfg, err := project.LoadConfig(dir)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	if err := sync.Ensure(dir, cfg); err != nil {
+		return fmt.Errorf("sync: %w", err)
+	}
+
+	lock, err := project.LoadLock(dir)
+	if err != nil {
+		return fmt.Errorf("load lockfile: %w", err)
+	}
+	switchPath := lock.SwitchPath
+
+	fmt.Println("Building...")
+	return exec.Run("opam", []string{
+		"exec", "--switch", switchPath, "--", "dune", "build",
+	}, exec.Options{Dir: dir})
 }
 
 func init() {

--- a/cmd/build_test.go
+++ b/cmd/build_test.go
@@ -1,0 +1,34 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/emilkloeden/oc/cmd"
+)
+
+// validOcToml returns minimal valid oc.toml content for the given project name.
+func validOcToml(name string) string {
+	return "[project]\nname = \"" + name + "\"\nversion = \"0.1.0\"\n\n[ocaml]\nversion = \"5.2.0\"\n"
+}
+
+func TestRunBuild_CorruptedLock_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a valid oc.toml so LoadConfig succeeds.
+	if err := os.WriteFile(filepath.Join(dir, "oc.toml"), []byte(validOcToml("myapp")), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a corrupted oc.lock file.
+	if err := os.WriteFile(filepath.Join(dir, "oc.lock"), []byte("NOT VALID TOML ][[["), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// RunBuild should return an error (not panic) when oc.lock is corrupted.
+	err := cmd.RunBuild(dir)
+	if err == nil {
+		t.Fatal("expected error when oc.lock is corrupted, got nil")
+	}
+}

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -11,3 +11,5 @@ var PrintEnvInfo = func(w io.Writer, lock *project.Lock) { printEnvInfo(w, lock)
 var FindProjectRoot = findProjectRoot
 var BuildRunArgs = buildRunArgs
 var ParseAddArgs = parseAddArgs
+var RunBuild = runBuild
+var RunRemove = runRemove

--- a/cmd/remove.go
+++ b/cmd/remove.go
@@ -14,40 +14,44 @@ var removeCmd = &cobra.Command{
 	Short: "Remove a dependency from the project",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pkg := args[0]
-
 		dir, err := projectRoot()
 		if err != nil {
 			return err
 		}
-
-		cfg, err := project.LoadConfig(dir)
-		if err != nil {
-			return err
-		}
-
-		_, inDeps := cfg.Dependencies[pkg]
-		_, inDev := cfg.DevDependencies[pkg]
-		if !inDeps && !inDev {
-			return fmt.Errorf("%q is not a dependency of this project", pkg)
-		}
-
-		delete(cfg.Dependencies, pkg)
-		delete(cfg.DevDependencies, pkg)
-
-		if err := project.SaveConfig(dir, cfg); err != nil {
-			return fmt.Errorf("save oc.toml: %w", err)
-		}
-		if err := opam.Generate(dir, cfg); err != nil {
-			return fmt.Errorf("regenerate opam file: %w", err)
-		}
-
-		fmt.Printf("Removing %s...\n", pkg)
-		_ = exec.Run("opam", []string{"remove", pkg, "--yes"}, exec.Options{Dir: dir})
-
-		fmt.Printf("Removed %q from dependencies.\n", pkg)
-		return nil
+		return runRemove(dir, args[0])
 	},
+}
+
+// runRemove removes a dependency from the project configuration and uninstalls it via opam.
+func runRemove(dir, pkg string) error {
+	cfg, err := project.LoadConfig(dir)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	_, inDeps := cfg.Dependencies[pkg]
+	_, inDev := cfg.DevDependencies[pkg]
+	if !inDeps && !inDev {
+		return fmt.Errorf("%q is not a dependency of this project", pkg)
+	}
+
+	delete(cfg.Dependencies, pkg)
+	delete(cfg.DevDependencies, pkg)
+
+	if err := project.SaveConfig(dir, cfg); err != nil {
+		return fmt.Errorf("save oc.toml: %w", err)
+	}
+	if err := opam.Generate(dir, cfg); err != nil {
+		return fmt.Errorf("regenerate opam file: %w", err)
+	}
+
+	fmt.Printf("Removing %s...\n", pkg)
+	if err := exec.Run("opam", []string{"remove", pkg, "--yes"}, exec.Options{Dir: dir}); err != nil {
+		return fmt.Errorf("opam remove: %w", err)
+	}
+
+	fmt.Printf("Removed %q from dependencies.\n", pkg)
+	return nil
 }
 
 func init() {

--- a/cmd/remove_test.go
+++ b/cmd/remove_test.go
@@ -1,0 +1,33 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/emilkloeden/oc/cmd"
+)
+
+func TestRunRemove_OpamFailurePropagates(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a valid oc.toml with a dependency.
+	content := "[project]\nname = \"myapp\"\nversion = \"0.1.0\"\n\n[ocaml]\nversion = \"5.2.0\"\n\n[dependencies]\nfakedep = \"*\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "oc.toml"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a stub .opam file so opam.Generate doesn't need to create it.
+	opamContent := "opam-version: \"2.0\"\nname: \"myapp\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "myapp.opam"), []byte(opamContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// RunRemove should propagate the opam error instead of silently ignoring it.
+	// Since opam is either not installed or "fakedep" is not a real package,
+	// the opam remove call will fail and the error must be returned.
+	err := cmd.RunRemove(dir, "fakedep")
+	if err == nil {
+		t.Fatal("expected error when opam remove fails, got nil")
+	}
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -27,22 +27,29 @@ var runCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-
-		cfg, err := project.LoadConfig(dir)
-		if err != nil {
-			return err
-		}
-
-		if err := sync.Ensure(dir, cfg); err != nil {
-			return err
-		}
-
-		lock, _ := project.LoadLock(dir)
-		switchPath := lock.SwitchPath
-
-		fmt.Println("Building and running...")
-		return exec.Run("opam", buildRunArgs(switchPath, args...), exec.Options{Dir: dir})
+		return runRun(dir, args)
 	},
+}
+
+// runRun performs the build-and-run for the given project directory.
+func runRun(dir string, args []string) error {
+	cfg, err := project.LoadConfig(dir)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	if err := sync.Ensure(dir, cfg); err != nil {
+		return fmt.Errorf("sync: %w", err)
+	}
+
+	lock, err := project.LoadLock(dir)
+	if err != nil {
+		return fmt.Errorf("load lockfile: %w", err)
+	}
+	switchPath := lock.SwitchPath
+
+	fmt.Println("Building and running...")
+	return exec.Run("opam", buildRunArgs(switchPath, args...), exec.Options{Dir: dir})
 }
 
 func init() {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -210,6 +210,7 @@ func TestSaveLock_ConcurrentWritesProduceValidFile(t *testing.T) {
 	}
 }
 
+
 func TestSaveLock_RoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	lock := &project.Lock{


### PR DESCRIPTION
## Summary

- **Issue #10**: `cmd/build.go` and `cmd/run.go` discarded the error from `project.LoadLock` with `lock, _ := ...` and then immediately dereferenced the potentially-nil pointer, causing a panic when `oc.lock` is present but unparseable. Fixed by checking the error and returning `fmt.Errorf("load lockfile: %w", err)`.
- **Issue #12**: `cmd/remove.go` assigned the result of `exec.Run("opam", ...)` to `_`, so a failed `opam remove` printed "Removed from dependencies" regardless. Fixed by checking the error and returning `fmt.Errorf("opam remove: %w", err)`.
- **Issue #15 (partial)**: Bare `return err` calls in the same three files wrapped with `fmt.Errorf` context strings.

Business logic in each command extracted into `runBuild`, `runRun`, and `runRemove` helpers following the pattern established by `RunNew` in `new.go`.

## Test plan

- [ ] `go test ./...` passes (all new tests green, no regressions)
- [ ] `golangci-lint run ./...` reports 0 issues
- [ ] `TestLoadLock_CorruptedFile` — verifies `project.LoadLock` returns `nil, err` for invalid TOML
- [ ] `TestRunBuild_CorruptedLock_ReturnsError` — verifies `runBuild` returns an error (not a panic) when `oc.lock` is corrupted
- [ ] `TestRunRemove_OpamFailurePropagates` — verifies `runRemove` returns an error when `opam remove` fails

Closes #10, Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)