### PR TITLE
chore: standardise error wrapping and add edge case test coverage

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -49,7 +49,7 @@ var addCmd = &cobra.Command{
 
 		// sync.Ensure installs deps, updates the lockfile, and ensures the switch exists.
 		if err := sync.Ensure(dir, cfg); err != nil {
-			return err
+			return fmt.Errorf("sync: %w", err)
 		}
 
 		for _, d := range deps {

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -68,6 +68,50 @@ func TestParseAddArgs_Empty_ReturnsError(t *testing.T) {
 	}
 }
 
+// TestParseAddArgs_InvalidConstraintPassedThrough documents that parseAddArgs does not
+// validate the version portion of a constraint — it passes the token through to opam as-is.
+// Validation of version strings is opam's responsibility.
+func TestParseAddArgs_InvalidConstraintPassedThrough(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg", ">=invalid"})
+	if err != nil {
+		t.Fatalf("expected parseAddArgs to accept a syntactically-valid-but-semantically-invalid constraint, got error: %v", err)
+	}
+	want := []project.Dep{{Name: "pkg", Constraint: ">=invalid"}}
+	assertDeps(t, deps, want)
+}
+
+// TestParseAddArgs_ConstraintOnlyNoPackage documents that a leading constraint token
+// (with no preceding package name) returns an error.
+func TestParseAddArgs_ConstraintOnlyNoPackage(t *testing.T) {
+	_, err := cmd.ParseAddArgs([]string{">=1.0"})
+	if err == nil {
+		t.Fatal("expected error when constraint is given before any package name, got nil")
+	}
+}
+
+// TestParseAddArgs_EmptyConstraintOperatorPassedThrough documents that a bare operator
+// token (e.g. ">=") that starts with a constraint prefix is treated as a constraint
+// and attached to the preceding package.
+func TestParseAddArgs_EmptyConstraintOperatorPassedThrough(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg", ">="})
+	if err != nil {
+		t.Fatalf("expected parseAddArgs to accept a bare operator as a constraint token, got error: %v", err)
+	}
+	want := []project.Dep{{Name: "pkg", Constraint: ">="}}
+	assertDeps(t, deps, want)
+}
+
+// TestParseAddArgs_WildcardConstraint documents that "*" is a valid constraint token
+// and results in no version constraint in the generated opam file.
+func TestParseAddArgs_WildcardConstraint(t *testing.T) {
+	deps, err := cmd.ParseAddArgs([]string{"pkg", "*"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := []project.Dep{{Name: "pkg", Constraint: "*"}}
+	assertDeps(t, deps, want)
+}
+
 // assertDeps checks that got matches want (order-sensitive).
 func assertDeps(t *testing.T, got, want []project.Dep) {
 	t.Helper()

--- a/internal/dune/dune.go
+++ b/internal/dune/dune.go
@@ -10,30 +10,36 @@ const duneVersion = "3.0"
 
 func ScaffoldBin(dir, name string) error {
 	if err := writeIfAbsent(filepath.Join(dir, "dune-project"), duneProject(name)); err != nil {
-		return err
+		return fmt.Errorf("write dune-project: %w", err)
 	}
 	binDir := filepath.Join(dir, "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
-		return err
+		return fmt.Errorf("create bin directory: %w", err)
 	}
 	if err := writeIfAbsent(filepath.Join(binDir, "dune"), binDune(name)); err != nil {
-		return err
+		return fmt.Errorf("write bin/dune: %w", err)
 	}
-	return writeIfAbsent(filepath.Join(binDir, "main.ml"), mainML(name))
+	if err := writeIfAbsent(filepath.Join(binDir, "main.ml"), mainML(name)); err != nil {
+		return fmt.Errorf("write bin/main.ml: %w", err)
+	}
+	return nil
 }
 
 func ScaffoldLib(dir, name string) error {
 	if err := writeIfAbsent(filepath.Join(dir, "dune-project"), duneProject(name)); err != nil {
-		return err
+		return fmt.Errorf("write dune-project: %w", err)
 	}
 	libDir := filepath.Join(dir, "lib")
 	if err := os.MkdirAll(libDir, 0755); err != nil {
-		return err
+		return fmt.Errorf("create lib directory: %w", err)
 	}
 	if err := writeIfAbsent(filepath.Join(libDir, "dune"), libDune(name)); err != nil {
-		return err
+		return fmt.Errorf("write lib/dune: %w", err)
 	}
-	return writeIfAbsent(filepath.Join(libDir, name+".ml"), libML(name))
+	if err := writeIfAbsent(filepath.Join(libDir, name+".ml"), libML(name)); err != nil {
+		return fmt.Errorf("write lib/%s.ml: %w", name, err)
+	}
+	return nil
 }
 
 func duneProject(name string) string {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -28,7 +28,7 @@ func (r *realRunner) SwitchExists(path string) bool {
 
 func (r *realRunner) CreateSwitch(path, ocamlVersion string) error {
 	if err := os.MkdirAll(path, 0755); err != nil {
-		return err
+		return fmt.Errorf("create switch directory: %w", err)
 	}
 	fmt.Printf("Creating OCaml %s switch (this may take a minute)...\n", ocamlVersion)
 	return exec.Run("opam", []string{
@@ -79,7 +79,7 @@ func Ensure(dir string, cfg *project.Config) error {
 func EnsureWith(dir string, cfg *project.Config, runner OpamRunner) error {
 	lock, err := project.LoadLock(dir)
 	if err != nil {
-		return err
+		return fmt.Errorf("load lockfile: %w", err)
 	}
 	// Detect OCaml version change — stale switch path must be discarded.
 	if lock.OCaml.Version != "" && lock.OCaml.Version != cfg.OCaml.Version {


### PR DESCRIPTION
## Summary

- Wraps bare `return err` statements in `internal/dune` (scaffold functions) and `internal/sync` (`CreateSwitch`, `EnsureWith`) with contextual `fmt.Errorf` messages so callers can identify which step in a multi-step operation failed
- Wraps the bare `sync.Ensure` return in `cmd/add.go` for consistent context at the command layer
- Adds four edge-case tests for `parseAddArgs` documenting current behaviour:
  - `TestParseAddArgs_InvalidConstraintPassedThrough`: invalid version strings (`>=invalid`) are passed through to opam unchanged
  - `TestParseAddArgs_ConstraintOnlyNoPackage`: a leading constraint token with no preceding package name returns an error
  - `TestParseAddArgs_EmptyConstraintOperatorPassedThrough`: a bare operator token (`>=`) is treated as a constraint and passed through
  - `TestParseAddArgs_WildcardConstraint`: `*` is a valid constraint token producing no version restriction

Files **not** modified (being handled in separate fix PRs): `build.go`, `run.go`, `remove.go`, `switch.go`, `new.go`, `project.go`.

## Test plan

- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] All four new edge-case tests pass and document current `parseAddArgs` behaviour

Closes #15
Closes #16 (partial — remove failure coverage deferred to fix PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)