### PR TITLE
docs: improve README, install script, and add CONTRIBUTING

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ go test ./...
 go test -tags integration -timeout 20m .
 ```
 
-Go 1.26+ is required. `opam` and `git` must be on `PATH` at runtime but are not needed to compile.
+Go 1.22+ is required. `opam` and `git` must be on `PATH` at runtime but are not needed to compile.
 
 ### Pre-commit checks (automated)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing to oc
+
+## Development setup
+
+Go 1.22+ is required. [opam](https://opam.ocaml.org/doc/Install.html) and [git](https://git-scm.com) must be on `PATH` at runtime but are not needed to compile or run unit tests.
+
+## Workflow
+
+This project follows a strict TDD cycle: write a failing test, confirm it fails, write the minimum implementation to pass it, confirm it passes.
+
+## Build and test
+
+```sh
+# Build
+go build ./...
+
+# Unit tests (no opam needed)
+go test ./...
+
+# Integration tests (opam must be installed and initialised)
+opam init --bare
+go test -tags integration -timeout 20m .
+```
+
+## Commit style
+
+Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add oc upgrade command
+fix: correct switch path on second sync
+chore: bump BurntSushi/toml to v1.5
+```
+
+`feat:` and `fix:` appear in the release changelog; `chore:`, `docs:`, `test:`, `ci:` do not.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ curl -sSfL https://raw.githubusercontent.com/emilkloeden/oc/main/install.sh | sh
 Detects your OS and architecture, downloads the correct binary from the latest release, and installs to `/usr/local/bin` (uses `sudo` if needed). To install elsewhere:
 
 ```sh
-INSTALL_DIR=~/.local/bin curl -sSfL https://raw.githubusercontent.com/emilkloeden/oc/main/install.sh | sh
+curl -sSfL https://raw.githubusercontent.com/emilkloeden/oc/main/install.sh | INSTALL_DIR=~/.local/bin sh
 ```
 
 ### Manual
@@ -77,7 +77,7 @@ Sync dependencies and build.
 oc build
 ```
 
-Ensures the project switch exists, installs any missing deps, then runs `dune build`.
+Ensures the project switch exists, installs any missing dependencies, then runs `dune build`.
 
 ### `oc run`
 
@@ -160,11 +160,29 @@ alcotest = "*"
     └── a5ea70a0aa46624e/   ← shared by any project with this exact dep set
 ```
 
-## Running integration tests
+## Why oc?
 
-Unit tests (`go test ./...`) run without opam. Integration tests require opam to be initialised:
+Raw opam is powerful but manual. A typical project setup looks like:
 
 ```sh
-opam init --bare
-go test -tags integration -timeout 20m .
+opam switch create my_app 5.2.0
+eval $(opam env)
+opam install dune cohttp-lwt-unix
+dune init project my_app
 ```
+
+And that's before you've written a line of OCaml. Switch to a different project and repeat — or remember which switch you're on.
+
+With `oc`:
+
+```sh
+oc new my_app
+cd my_app
+oc run
+```
+
+`oc` handles switch creation, environment activation, and dependency installation automatically. It doesn't replace opam or dune — it orchestrates them so you don't have to.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, the TDD workflow this project follows, and how to run integration tests.

--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,16 @@ REPO="emilkloeden/oc"
 BIN="oc"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 
+echo "==> Installing oc — the Cargo-like experience for OCaml"
+echo ""
+
 # Detect OS
 OS="$(uname -s)"
 case "$OS" in
   Linux)  os="linux"  ;;
   Darwin) os="darwin" ;;
   *)
-    echo "Unsupported OS: $OS" >&2
+    echo "Error: unsupported OS: $OS" >&2
     exit 1
     ;;
 esac
@@ -22,25 +25,29 @@ case "$ARCH" in
   x86_64 | amd64) arch="x86_64" ;;
   arm64 | aarch64) arch="arm64"  ;;
   *)
-    echo "Unsupported architecture: $ARCH" >&2
+    echo "Error: unsupported architecture: $ARCH" >&2
     exit 1
     ;;
 esac
 
 # Resolve latest version (can be overridden: VERSION=v1.2.3 ./install.sh)
-VERSION="${VERSION:-$(curl -sSfL "https://api.github.com/repos/${REPO}/releases/latest" \
-  | grep '"tag_name"' \
-  | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')}"
-
 if [ -z "$VERSION" ]; then
-  echo "Could not determine latest release version." >&2
-  exit 1
+  printf "==> Fetching latest release ... "
+  VERSION="$(curl -sSfL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' \
+    | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')"
+  if [ -z "$VERSION" ]; then
+    echo ""
+    echo "Error: could not determine latest release version." >&2
+    exit 1
+  fi
+  echo "$VERSION"
 fi
 
 TARBALL="${BIN}_${os}_${arch}.tar.gz"
 URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
 
-echo "Installing ${BIN} ${VERSION} (${os}/${arch}) to ${INSTALL_DIR} ..."
+printf "==> Downloading %s %s (%s/%s) ... " "$BIN" "$VERSION" "$os" "$arch"
 
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
@@ -48,16 +55,40 @@ trap 'rm -rf "$TMP"' EXIT
 curl -sSfL "$URL" | tar -xz -C "$TMP"
 
 if [ ! -f "${TMP}/${BIN}" ]; then
-  echo "Binary not found in archive." >&2
+  echo ""
+  echo "Error: binary not found in archive." >&2
   exit 1
 fi
+
+echo "done"
 
 chmod +x "${TMP}/${BIN}"
 
 if [ -w "$INSTALL_DIR" ]; then
+  printf "==> Installing to %s ... " "${INSTALL_DIR}/${BIN}"
   mv "${TMP}/${BIN}" "${INSTALL_DIR}/${BIN}"
+  echo "done"
 else
+  echo "==> Installing to ${INSTALL_DIR}/${BIN} (needs sudo) ..."
   sudo mv "${TMP}/${BIN}" "${INSTALL_DIR}/${BIN}"
 fi
 
-echo "Done. Run: ${BIN} --version"
+# Warn if INSTALL_DIR is not on PATH
+case ":${PATH}:" in
+  *":${INSTALL_DIR}:"*) ;;
+  *)
+    echo ""
+    echo "Warning: ${INSTALL_DIR} is not in your PATH."
+    echo "  Add this to your shell profile:"
+    echo "    export PATH=\"\$PATH:${INSTALL_DIR}\""
+    ;;
+esac
+
+echo ""
+echo "oc ${VERSION} installed. Get started:"
+echo ""
+echo "  oc new my_app        # create a new project"
+echo "  oc add cohttp        # add a dependency"
+echo "  oc build             # build your project"
+echo "  oc help              # see all commands"
+echo ""


### PR DESCRIPTION
## Summary

- Rewrites `install.sh` to show step-by-step progress, announce when sudo is needed, warn if `INSTALL_DIR` is not on `PATH`, and print a friendly next-steps block after installation
- Fixes `INSTALL_DIR` env var syntax in README (previous form wasn't passed into the piped shell)
- Adds a "Why oc?" section to README with a before/after comparison against raw opam
- Replaces "deps" with "dependencies" in prose throughout
- Links [opam](https://opam.ocaml.org/doc/Install.html) and [git](https://git-scm.com) in CONTRIBUTING.md
- Moves integration test instructions from README into a new CONTRIBUTING.md
- Corrects Go minimum version to 1.22 (per `go.mod`) in README, CONTRIBUTING.md, and CLAUDE.md — was incorrectly stated as 1.26

## Test plan

- [ ] Run the install script in a clean environment and verify progress output is readable
- [ ] Confirm `curl ... | INSTALL_DIR=~/.local/bin sh` syntax works correctly
- [ ] Review README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)