### PR TITLE
feat: replace oc.lock with .oc/state.toml and *.opam.locked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dist/
 *.swp
 *.swo
 
+# oc machine-local state (per-project, never committed)
+.oc/
+
 # Other
 initial.md
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What this project is
 
-`oc` is a Go CLI tool that wraps [opam](https://opam.ocaml.org) and [dune](https://dune.build) to give OCaml a Cargo-like developer experience. It manages per-project opam switches transparently, generates opam files from `oc.toml`, and keeps a lockfile of resolved package versions.
+`oc` is a Go CLI tool that wraps [opam](https://opam.ocaml.org) and [dune](https://dune.build) to give OCaml a Cargo-like developer experience. It manages per-project opam switches transparently and uses native `dune-project`/`.opam` files as the project source of truth.
 
 ## Development workflow
 
@@ -103,32 +103,41 @@ GoReleaser builds binaries for Linux/macOS/Windows (amd64 + arm64), creates a Gi
 main.go                  → entry point, delegates to cmd.Execute()
 cmd/                     → cobra commands; no business logic, just routing
   new.go                 → oc new: RunNew(parent, name, lib) is exported for tests
-  add.go                 → oc add: updates oc.toml + opam file, then calls sync.Ensure
+  add.go                 → oc add: updates dune-project/.opam, then calls sync.Ensure
   remove.go              → oc remove: inverse of add
   build.go               → oc build: sync.Ensure → opam exec dune build
   run.go                 → oc run:   sync.Ensure → opam exec dune exec ./bin/main.exe
-  env.go                 → oc env: reads oc.lock, prints OCaml version + packages
-  util.go                → findProjectRoot: walks up from cwd looking for oc.toml
-  export_test.go         → exposes unexported helpers (printEnvInfo, findProjectRoot) for tests
+  env.go                 → oc env: reads OCaml version from .opam, switch path from state
+  migrate.go             → silently migrates oc.lock → .oc/state.toml on upgrade
+  util.go                → findProjectRoot: walks up from cwd looking for dune-project/.opam
+  export_test.go         → exposes unexported helpers (findProjectRoot, formatEnvOutput) for tests
 
-internal/project/        → oc.toml and oc.lock read/write (pure, no subprocess calls)
-  Config struct          → [project], [ocaml], [dependencies], [dev-dependencies]
-  Lock struct            → [ocaml], switch_path, [[package]] list
-  LoadConfig/SaveConfig  → TOML round-trip for oc.toml
-  LoadLock/SaveLock      → TOML round-trip for oc.lock; missing lock returns empty Lock{}
+internal/project/        → .oc/state.toml read/write (pure, no subprocess calls)
+  State struct           → switch_path, ocaml_version (machine-local; gitignored)
+  LoadState/SaveState    → TOML round-trip for .oc/state.toml; missing file returns empty State{}
+  Dep struct             → parsed package name + version constraint from CLI arguments
 
-internal/opam/           → generates <name>.opam from a Config (pure, no subprocess calls)
-  Generate(dir, cfg)     → always emits synopsis, maintainer, ocaml constraint, dune dep
+internal/opam/           → .opam file parsing and manipulation (pure, no subprocess calls)
+  FindOpamFile(dir)      → finds single *.opam file in dir
+  ReadOCamlVersion(dir)  → extracts ocaml version from depends: block
+  AddDepToOpam(path, pkg, constraint) → inserts before closing ]
+  RemoveDepFromOpam(path, pkg)        → line-by-line removal
 
-internal/switch/         → switch hashing and symlink management (package name: swmgr)
-  Hash(lock)             → SHA-256 of sorted "name=version\n" lines, first 16 hex chars
-  CachePath(lock)        → ~/.cache/oc/switches/<hash>
-  EnsureSymlink(dir, target) → creates or updates .ocaml/ symlink in project root
+internal/dune/           → dune-project parsing and manipulation (pure, no subprocess calls)
+  HasGenerateOpamFiles(dir) → checks for (generate_opam_files true)
+  AddDep/RemoveDep(dir, pkg, constraint) → edit (depends ...) block
+  ScaffoldBin/ScaffoldLib(dir, name, maintainer) → create project skeleton
+
+internal/project/detect  → Detect(dir) → TypeDuneManaged | TypeHandWrittenOpam
+
+internal/switch/         → switch path computation and symlink management (package name: swmgr)
+  CachePathForVersion(ocamlVersion) → ~/.cache/oc/switches/<hash> (SHA-256 of ocaml=VERSION)
+  EnsureSymlink(dir, target)        → creates or updates .ocaml/ symlink in project root
 
 internal/sync/           → orchestrates switch lifecycle and dep installation
-  Ensure(dir, cfg)       → real opam runner entry point
-  EnsureWith(dir, cfg, OpamRunner) → injectable for unit tests
-  OpamRunner interface   → SwitchExists, CreateSwitch, InstallDeps, ListInstalled
+  Ensure(dir)            → real opam runner entry point; reads OCaml version from .opam file
+  EnsureWith(dir, ocamlVersion, OpamRunner) → injectable for unit tests
+  OpamRunner interface   → SwitchExists, CreateSwitch, InstallDeps, LockDeps
 
 internal/exec/           → thin subprocess wrapper
   Run(name, args, opts)  → streams stdout/stderr; opts: Dir, Env, Stdout, Stderr
@@ -137,9 +146,11 @@ internal/exec/           → thin subprocess wrapper
 
 ## Key design decisions
 
-**Switch path is stored in oc.lock** (`switch_path` field). The content-addressed hash is computed from the lock before packages are installed; after installation the lock is populated with actual package versions which would change the hash. Persisting the resolved path prevents the switch from being "lost" on the second sync call.
+**Switch path is stored in `.oc/state.toml`** (gitignored). This is machine-local state. The content-addressed path is derived from the OCaml version hash on first run; subsequent runs reuse the stored path for stability. On an OCaml version change, the stored path is discarded and a new one computed.
 
-**opam file is always generated, never edited by users.** `oc.toml` is the single source of truth. `opam.Generate` is called whenever `oc.toml` changes (new, add, remove).
+**`*.opam.locked` is the committed reproducibility artifact** (generated by `opam lock .` after install). Experienced opam users can run `opam install --locked` directly without `oc`.
+
+**`dune-project` and `.opam` are the source of truth for dependencies.** `oc add`/`oc remove` edit these files directly; `oc` does not maintain its own manifest. For dune-managed projects, `dune-project` is edited; for hand-written opam files, the `.opam` file is edited directly.
 
 **`dune` is always included as an implicit dependency** in the generated opam file so `opam install --deps-only` always installs it.
 
@@ -151,10 +162,10 @@ internal/exec/           → thin subprocess wrapper
 
 | File | Owned by | Notes |
 |---|---|---|
-| `oc.toml` | user | edit freely |
-| `oc.lock` | `oc` | generated; commit for reproducibility |
-| `<name>.opam` | `oc` | generated; do not edit |
 | `dune-project` | user | scaffolded once; edit freely |
+| `<name>.opam` | user (dune-managed: generated by dune) | for hand-written: edit directly |
+| `<name>.opam.locked` | `oc` | generated by `opam lock .`; commit for reproducibility |
+| `.oc/state.toml` | `oc` | machine-local; gitignored; do not edit |
 | `bin/dune`, `lib/dune` | user | scaffolded once; edit freely |
 | `.ocaml/` | `oc` | symlink to switch; gitignored |
 
@@ -166,11 +177,13 @@ internal/exec/           → thin subprocess wrapper
 4. Write tests in `cmd/<name>_test.go` using `package cmd_test`.
 5. For logic touching opam, add an integration test in `integration_test.go` with `//go:build integration`.
 
-## Constraint syntax in oc.toml
+## Constraint syntax for `oc add`
 
-| oc.toml value | opam output |
-|---|---|
-| `"*"` | `"pkg"` (no constraint) |
-| `">=5.0.0"` | `"pkg" {>= "5.0.0"}` |
-| `"<=2.0"` | `"pkg" {<= "2.0"}` |
-| `"=1.0.0"` | `"pkg" {= "1.0.0"}` |
+The constraint argument to `oc add <pkg> --constraint <c>` is parsed by `internal/opam/parse.go` and `internal/dune/parse.go`.
+
+| CLI value | dune-project output | opam output |
+|---|---|---|
+| `"*"` or `""` | `pkg` (no constraint) | `"pkg"` |
+| `">=5.0.0"` | `(pkg (>= "5.0.0"))` | `"pkg" {>= "5.0.0"}` |
+| `"<=2.0"` | `(pkg (<= "2.0"))` | `"pkg" {<= "2.0"}` |
+| `"=1.0.0"` | `(pkg (= "1.0.0"))` | `"pkg" {= "1.0.0"}` |

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -27,15 +27,14 @@ func runBuild(dir string) error {
 		return fmt.Errorf("sync: %w", err)
 	}
 
-	lock, err := project.LoadLock(dir)
+	state, err := project.LoadState(dir)
 	if err != nil {
-		return fmt.Errorf("load lockfile: %w", err)
+		return fmt.Errorf("load state: %w", err)
 	}
-	switchPath := lock.SwitchPath
 
 	fmt.Println("Building...")
 	return exec.Run("opam", []string{
-		"exec", "--switch", switchPath, "--", "dune", "build",
+		"exec", "--switch", state.SwitchPath, "--", "dune", "build",
 	}, exec.Options{Dir: dir})
 }
 

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -2,9 +2,9 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"os"
+	"strings"
 
+	"github.com/emilkloeden/oc/internal/opam"
 	"github.com/emilkloeden/oc/internal/project"
 	"github.com/spf13/cobra"
 )
@@ -18,34 +18,30 @@ var envCmd = &cobra.Command{
 			return err
 		}
 
-		lock, err := project.LoadLock(dir)
+		ocamlVersion, err := opam.ReadOCamlVersion(dir)
+		if err != nil {
+			ocamlVersion = "(unknown)"
+		}
+
+		state, err := project.LoadState(dir)
 		if err != nil {
 			return err
 		}
 
-		printEnvInfo(os.Stdout, lock)
-
-		if lock.SwitchPath != "" {
-			fmt.Printf("switch   %s\n", lock.SwitchPath)
-		} else {
-			fmt.Printf("switch   (not yet initialised — run 'oc build')\n")
-		}
+		fmt.Print(formatEnvOutput(ocamlVersion, state.SwitchPath))
 		return nil
 	},
 }
 
-func printEnvInfo(w io.Writer, lock *project.Lock) {
-	fmt.Fprintf(w, "ocaml    %s\n", lock.OCaml.Version)
-
-	if len(lock.Packages) == 0 {
-		fmt.Fprintf(w, "packages (no packages installed)\n")
-		return
+func formatEnvOutput(ocamlVersion, switchPath string) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "ocaml    %s\n", ocamlVersion)
+	if switchPath != "" {
+		fmt.Fprintf(&b, "switch   %s\n", switchPath)
+	} else {
+		fmt.Fprintf(&b, "switch   (not yet initialised — run 'oc build')\n")
 	}
-
-	fmt.Fprintf(w, "packages (%d installed)\n", len(lock.Packages))
-	for _, p := range lock.Packages {
-		fmt.Fprintf(w, "  %-30s %s\n", p.Name, p.Version)
-	}
+	return b.String()
 }
 
 func init() {

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,7 +1,6 @@
 package cmd_test
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,54 +9,6 @@ import (
 	"github.com/emilkloeden/oc/cmd"
 	"github.com/emilkloeden/oc/internal/project"
 )
-
-// loadEnvOutput scaffolds an oc project in a temp dir and captures the env
-// command output by calling the formatting logic directly.
-func loadEnvOutput(t *testing.T, lock *project.Lock) string {
-	t.Helper()
-	var buf bytes.Buffer
-	cmd.PrintEnvInfo(&buf, lock)
-	return buf.String()
-}
-
-func TestEnvOutput_ShowsOCamlVersion(t *testing.T) {
-	lock := &project.Lock{
-		OCaml:    project.OCamlMeta{Version: "5.2.0"},
-		Packages: []project.Package{},
-	}
-	out := loadEnvOutput(t, lock)
-	if !strings.Contains(out, "5.2.0") {
-		t.Errorf("expected OCaml version in output, got:\n%s", out)
-	}
-}
-
-func TestEnvOutput_ShowsPackages(t *testing.T) {
-	lock := &project.Lock{
-		OCaml: project.OCamlMeta{Version: "5.2.0"},
-		Packages: []project.Package{
-			{Name: "cohttp", Version: "5.0.0"},
-			{Name: "lwt", Version: "5.7.0"},
-		},
-	}
-	out := loadEnvOutput(t, lock)
-	if !strings.Contains(out, "cohttp") {
-		t.Errorf("expected cohttp in output, got:\n%s", out)
-	}
-	if !strings.Contains(out, "lwt") {
-		t.Errorf("expected lwt in output, got:\n%s", out)
-	}
-}
-
-func TestEnvOutput_EmptyPackages(t *testing.T) {
-	lock := &project.Lock{
-		OCaml:    project.OCamlMeta{Version: "5.2.0"},
-		Packages: []project.Package{},
-	}
-	out := loadEnvOutput(t, lock)
-	if !strings.Contains(out, "no packages") && !strings.Contains(out, "0 package") {
-		t.Errorf("expected empty package message, got:\n%s", out)
-	}
-}
 
 func TestProjectRoot_FindsDuneProject(t *testing.T) {
 	dir := t.TempDir()
@@ -76,5 +27,43 @@ func TestProjectRoot_FindsDuneProject(t *testing.T) {
 	}
 	if root != dir {
 		t.Errorf("got %q want %q", root, dir)
+	}
+}
+
+func TestFormatEnvOutput_ShowsOCamlVersion(t *testing.T) {
+	out := cmd.FormatEnvOutput("5.2.0", "")
+	if !strings.Contains(out, "5.2.0") {
+		t.Errorf("expected OCaml version in output, got:\n%s", out)
+	}
+}
+
+func TestFormatEnvOutput_ShowsSwitchPath(t *testing.T) {
+	out := cmd.FormatEnvOutput("5.2.0", "/cache/oc/switches/abc123/")
+	if !strings.Contains(out, "/cache/oc/switches/abc123/") {
+		t.Errorf("expected switch path in output, got:\n%s", out)
+	}
+}
+
+func TestFormatEnvOutput_ShowsUninitialised_WhenNoSwitchPath(t *testing.T) {
+	out := cmd.FormatEnvOutput("5.2.0", "")
+	if !strings.Contains(out, "not yet initialised") {
+		t.Errorf("expected uninitialised message in output, got:\n%s", out)
+	}
+}
+
+func TestEnvState_LoadsFromStateFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := project.SaveState(dir, project.State{
+		SwitchPath:   "/cache/switch",
+		OCamlVersion: "5.2.0",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	s, err := project.LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if s.SwitchPath != "/cache/switch" {
+		t.Errorf("SwitchPath: got %q", s.SwitchPath)
 	}
 }

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -1,14 +1,9 @@
 package cmd
 
-import (
-	"io"
-
-	"github.com/emilkloeden/oc/internal/project"
-)
-
 // Exported for testing only.
-var PrintEnvInfo = func(w io.Writer, lock *project.Lock) { printEnvInfo(w, lock) }
 var FindProjectRoot = findProjectRoot
+var FormatEnvOutput = formatEnvOutput
+var MigrateIfNeeded = migrateIfNeeded
 var BuildRunArgs = buildRunArgs
 var ParseAddArgs = parseAddArgs
 var RunBuild = runBuild

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,48 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/BurntSushi/toml"
+	"github.com/emilkloeden/oc/internal/project"
+)
+
+// oldLock mirrors the fields we need from the pre-v0.4.0 oc.lock format.
+type oldLock struct {
+	SwitchPath string `toml:"switch_path"`
+	OCaml      struct {
+		Version string `toml:"version"`
+	} `toml:"ocaml"`
+}
+
+// migrateIfNeeded silently migrates an old oc.lock to .oc/state.toml on first
+// run after a v0.4.0 upgrade. It is a no-op when oc.lock is absent or
+// .oc/state.toml already exists.
+func migrateIfNeeded(dir string) {
+	lockPath := filepath.Join(dir, "oc.lock")
+	data, err := os.ReadFile(lockPath)
+	if err != nil {
+		return // no oc.lock — nothing to migrate
+	}
+
+	// Skip if state already exists (migration was already done).
+	if _, err := os.Stat(filepath.Join(dir, ".oc", "state.toml")); err == nil {
+		return
+	}
+
+	var lock oldLock
+	if _, err := toml.Decode(string(data), &lock); err != nil {
+		return // corrupt lock; leave it alone
+	}
+
+	state := project.State{
+		SwitchPath:   lock.SwitchPath,
+		OCamlVersion: lock.OCaml.Version,
+	}
+	if err := project.SaveState(dir, state); err != nil {
+		return
+	}
+
+	_ = os.Remove(lockPath)
+}

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -1,0 +1,76 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/emilkloeden/oc/cmd"
+	"github.com/emilkloeden/oc/internal/project"
+)
+
+const oldLockContent = `
+switch_path = "/home/alice/.cache/oc/switches/abc123def456abcd"
+
+[ocaml]
+  version = "5.2.0"
+
+[[package]]
+  name = "dune"
+  version = "3.15.0"
+`
+
+func TestMigrateOcLock_MigratesWhenLockExists(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "oc.lock"), []byte(oldLockContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd.MigrateIfNeeded(dir)
+
+	// oc.lock should be deleted
+	if _, err := os.Stat(filepath.Join(dir, "oc.lock")); !os.IsNotExist(err) {
+		t.Error("expected oc.lock to be deleted after migration")
+	}
+
+	// .oc/state.toml should exist with the switch_path
+	s, err := project.LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState after migration: %v", err)
+	}
+	if s.SwitchPath != "/home/alice/.cache/oc/switches/abc123def456abcd" {
+		t.Errorf("SwitchPath after migration: got %q", s.SwitchPath)
+	}
+}
+
+func TestMigrateOcLock_NoopWhenNoLock(t *testing.T) {
+	dir := t.TempDir()
+	// Should not error or create any files
+	cmd.MigrateIfNeeded(dir)
+	if _, err := os.Stat(filepath.Join(dir, ".oc", "state.toml")); !os.IsNotExist(err) {
+		t.Error("expected no state.toml to be created when there is no oc.lock")
+	}
+}
+
+func TestMigrateOcLock_NoopWhenStateAlreadyExists(t *testing.T) {
+	dir := t.TempDir()
+	// Both files exist — state is newer, lock is leftover
+	if err := os.WriteFile(filepath.Join(dir, "oc.lock"), []byte(oldLockContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	existing := project.State{SwitchPath: "/existing/path", OCamlVersion: "5.3.0"}
+	if err := project.SaveState(dir, existing); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd.MigrateIfNeeded(dir)
+
+	// State should be unchanged (not overwritten by migration)
+	s, err := project.LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if s.SwitchPath != "/existing/path" {
+		t.Errorf("migration should not overwrite existing state; got SwitchPath %q", s.SwitchPath)
+	}
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -68,13 +68,10 @@ func RunNew(parent, name string, lib bool) error {
 		}
 	}
 
-	// Write initial oc.lock with the default OCaml version so sync.Ensure
-	// can create the right switch without needing oc.toml.
-	lock := &project.Lock{
-		OCaml: project.OCamlMeta{Version: "5.2.0"},
-	}
-	if err := project.SaveLock(dir, lock); err != nil {
-		return fmt.Errorf("write oc.lock: %w", err)
+	// Write initial .oc/state.toml so subsequent commands know the OCaml version.
+	state := project.State{OCamlVersion: "5.2.0"}
+	if err := project.SaveState(dir, state); err != nil {
+		return fmt.Errorf("write .oc/state.toml: %w", err)
 	}
 
 	if err := writeGitignore(dir); err != nil {
@@ -88,7 +85,7 @@ func RunNew(parent, name string, lib bool) error {
 }
 
 func writeGitignore(dir string) error {
-	content := ".ocaml/\n_build/\n*.install\n"
+	content := ".ocaml/\n.oc/\n_build/\n*.install\n"
 	return os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(content), 0644)
 }
 

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -38,7 +38,7 @@ func TestNew_GitignoreExcludesOcamlDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read .gitignore: %v", err)
 	}
-	for _, entry := range []string{".ocaml/", "_build/"} {
+	for _, entry := range []string{".ocaml/", ".oc/", "_build/"} {
 		found := false
 		for _, line := range splitLines(string(content)) {
 			if line == entry {
@@ -111,19 +111,19 @@ func TestNew_DuneProjectHasPackageStanza(t *testing.T) {
 	}
 }
 
-func TestNew_CreatesInitialLockWithOcamlVersion(t *testing.T) {
+func TestNew_CreatesInitialStateWithOcamlVersion(t *testing.T) {
 	dir := t.TempDir()
 	if err := cmd.RunNew(dir, "my_app", false); err != nil {
 		t.Fatalf("RunNew: %v", err)
 	}
 
-	lockPath := filepath.Join(dir, "my_app", "oc.lock")
-	if _, err := os.Stat(lockPath); err != nil {
-		t.Fatalf("expected oc.lock to exist: %v", err)
+	statePath := filepath.Join(dir, "my_app", ".oc", "state.toml")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("expected .oc/state.toml to exist: %v", err)
 	}
-	content, _ := os.ReadFile(lockPath)
+	content, _ := os.ReadFile(statePath)
 	if !strings.Contains(string(content), "5.2.0") {
-		t.Errorf("expected oc.lock to contain default OCaml version 5.2.0:\n%s", content)
+		t.Errorf("expected .oc/state.toml to contain default OCaml version 5.2.0:\n%s", content)
 	}
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -12,6 +12,12 @@ var currentVersion = "dev"
 var rootCmd = &cobra.Command{
 	Use:   "oc",
 	Short: "A Cargo-like developer experience for OCaml",
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// Silently migrate oc.lock → .oc/state.toml on first run after upgrade.
+		if dir, err := projectRoot(); err == nil {
+			migrateIfNeeded(dir)
+		}
+	},
 }
 
 func Execute() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,14 +37,13 @@ func runRun(dir string, args []string) error {
 		return fmt.Errorf("sync: %w", err)
 	}
 
-	lock, err := project.LoadLock(dir)
+	state, err := project.LoadState(dir)
 	if err != nil {
-		return fmt.Errorf("load lockfile: %w", err)
+		return fmt.Errorf("load state: %w", err)
 	}
-	switchPath := lock.SwitchPath
 
 	fmt.Println("Building and running...")
-	return exec.Run("opam", buildRunArgs(switchPath, args...), exec.Options{Dir: dir})
+	return exec.Run("opam", buildRunArgs(state.SwitchPath, args...), exec.Options{Dir: dir})
 }
 
 func init() {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -31,9 +31,12 @@ func findProjectRoot(start string) (string, error) {
 }
 
 // isProjectDir reports whether dir looks like an OCaml project root.
-// A project root has either a dune-project file or a *.opam file.
+// Recognised markers: dune-project, *.opam file, or .oc/ directory (oc state).
 func isProjectDir(dir string) bool {
 	if _, err := os.Stat(filepath.Join(dir, "dune-project")); err == nil {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".oc")); err == nil {
 		return true
 	}
 	entries, err := os.ReadDir(dir)

--- a/integration_test.go
+++ b/integration_test.go
@@ -3,6 +3,7 @@
 package main_test
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/emilkloeden/oc/cmd"
 	"github.com/emilkloeden/oc/internal/dune"
+	ocExec "github.com/emilkloeden/oc/internal/exec"
 	"github.com/emilkloeden/oc/internal/project"
 	"github.com/emilkloeden/oc/internal/sync"
 )
@@ -66,21 +68,21 @@ func TestIntegration_SyncCreatesSwitch(t *testing.T) {
 		t.Error(".ocaml should be a symlink")
 	}
 
-	// lockfile must be written
-	lock, err := project.LoadLock(projectDir)
+	// State must be written with a switch path
+	state, err := project.LoadState(projectDir)
 	if err != nil {
-		t.Fatalf("LoadLock: %v", err)
+		t.Fatalf("LoadState: %v", err)
 	}
-	if lock.OCaml.Version == "" {
-		t.Error("lockfile missing OCaml version")
+	if state.SwitchPath == "" {
+		t.Error("state missing SwitchPath after sync")
 	}
 }
 
-// TestIntegration_SwitchPathStoredInLock verifies that after sync the switch
-// path is persisted in oc.lock so subsequent calls stay on the same switch.
-func TestIntegration_SwitchPathStoredInLock(t *testing.T) {
+// TestIntegration_SwitchPathStoredInState verifies that after sync the switch
+// path is persisted in .oc/state.toml so subsequent calls stay on the same switch.
+func TestIntegration_SwitchPathStoredInState(t *testing.T) {
 	requireOpam(t)
-	t.Log("Creating a switch to verify lock persistence — may take several minutes on first run.")
+	t.Log("Creating a switch to verify state persistence — may take several minutes on first run.")
 
 	dir := t.TempDir()
 	if err := cmd.RunNew(dir, "hello", false); err != nil {
@@ -92,16 +94,16 @@ func TestIntegration_SwitchPathStoredInLock(t *testing.T) {
 		t.Fatalf("first sync.Ensure: %v", err)
 	}
 
-	lock1, _ := project.LoadLock(projectDir)
-	path1 := lock1.SwitchPath
+	s1, _ := project.LoadState(projectDir)
+	path1 := s1.SwitchPath
 
-	// Second sync — lock now has packages; without storing path, hash would differ.
+	// Second sync — should reuse stored path.
 	if err := sync.Ensure(projectDir); err != nil {
 		t.Fatalf("second sync.Ensure: %v", err)
 	}
 
-	lock2, _ := project.LoadLock(projectDir)
-	path2 := lock2.SwitchPath
+	s2, _ := project.LoadState(projectDir)
+	path2 := s2.SwitchPath
 
 	if path1 == "" {
 		t.Fatal("SwitchPath not stored after first sync")
@@ -127,16 +129,15 @@ func TestIntegration_BuildHelloWorld(t *testing.T) {
 		t.Fatalf("sync.Ensure: %v", err)
 	}
 
-	lock, err := project.LoadLock(projectDir)
+	state, err := project.LoadState(projectDir)
 	if err != nil {
-		t.Fatalf("LoadLock: %v", err)
+		t.Fatalf("LoadState: %v", err)
 	}
-	switchPath := lock.SwitchPath
-	if switchPath == "" {
-		t.Fatal("lock.SwitchPath empty after sync")
+	if state.SwitchPath == "" {
+		t.Fatal("state.SwitchPath empty after sync")
 	}
 
-	out, err := runCmd(projectDir, "opam", "exec", "--switch", switchPath, "--", "dune", "build")
+	out, err := runCmd(projectDir, "opam", "exec", "--switch", state.SwitchPath, "--", "dune", "build")
 	if err != nil {
 		t.Fatalf("dune build failed: %v\noutput: %s", err, out)
 	}
@@ -147,7 +148,8 @@ func TestIntegration_BuildHelloWorld(t *testing.T) {
 	}
 }
 
-// TestIntegration_AddDependency verifies oc add updates the lockfile.
+// TestIntegration_AddDependency verifies oc add installs a package and the
+// switch has it available after sync.
 func TestIntegration_AddDependency(t *testing.T) {
 	requireOpam(t)
 	t.Log("This test installs an opam package — may take several minutes.")
@@ -158,7 +160,7 @@ func TestIntegration_AddDependency(t *testing.T) {
 	}
 	projectDir := filepath.Join(dir, "hello")
 
-	// Add a small dep with no C deps for speed.
+	// Add a small dep with no C dependencies for speed.
 	if err := dune.AddDep(projectDir, "stringext", "*"); err != nil {
 		t.Fatalf("dune.AddDep: %v", err)
 	}
@@ -167,20 +169,21 @@ func TestIntegration_AddDependency(t *testing.T) {
 		t.Fatalf("sync.Ensure: %v", err)
 	}
 
-	lock, err := project.LoadLock(projectDir)
+	state, err := project.LoadState(projectDir)
 	if err != nil {
-		t.Fatalf("LoadLock: %v", err)
+		t.Fatalf("LoadState: %v", err)
 	}
 
-	found := false
-	for _, p := range lock.Packages {
-		if strings.EqualFold(p.Name, "stringext") {
-			found = true
-			break
-		}
+	// Verify stringext is installed in the switch.
+	var buf bytes.Buffer
+	if err := ocExec.Run("opam", []string{
+		"list", "--installed", "--short", "--columns=name",
+		"--switch", state.SwitchPath,
+	}, ocExec.Options{Stdout: &buf}); err != nil {
+		t.Fatalf("opam list: %v", err)
 	}
-	if !found {
-		t.Errorf("stringext not found in lockfile packages: %v", lock.Packages)
+	if !strings.Contains(buf.String(), "stringext") {
+		t.Errorf("stringext not installed in switch; opam list output:\n%s", buf.String())
 	}
 }
 

--- a/internal/opam/parse.go
+++ b/internal/opam/parse.go
@@ -144,3 +144,48 @@ func parseConstraintParts(c string) (op, ver string) {
 	}
 	return "", c
 }
+
+// ReadOCamlVersion reads the OCaml version constraint from the .opam file in dir.
+// It returns the version string from the first `"ocaml" {>= "x.y.z"}` or `{= "x.y.z"}` line.
+func ReadOCamlVersion(dir string) (string, error) {
+	path, err := FindOpamFile(dir)
+	if err != nil {
+		return "", err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("read opam file: %w", err)
+	}
+	_, end, err := findOpamDepsBounds(string(data))
+	if err != nil {
+		return "", fmt.Errorf("find depends block: %w", err)
+	}
+	// start is index after "depends: ["; search only inside the block
+	start, _, _ := findOpamDepsBounds(string(data))
+	block := string(data)[start:end]
+	for _, line := range strings.Split(block, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !strings.HasPrefix(trimmed, `"ocaml"`) {
+			continue
+		}
+		// Extract version from {>= "x.y.z"} or {= "x.y.z"}
+		open := strings.Index(trimmed, `"ocaml"`) + len(`"ocaml"`)
+		rest := strings.TrimSpace(trimmed[open:])
+		if !strings.HasPrefix(rest, "{") {
+			continue
+		}
+		inner := strings.TrimPrefix(rest, "{")
+		inner = strings.TrimSuffix(strings.TrimSpace(inner), "}")
+		inner = strings.TrimSpace(inner)
+		for _, op := range []string{">=", "<=", ">", "<", "="} {
+			if strings.HasPrefix(inner, op) {
+				ver := strings.TrimSpace(inner[len(op):])
+				ver = strings.Trim(ver, `"`)
+				if ver != "" {
+					return ver, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("no ocaml version constraint found in %s", path)
+}

--- a/internal/opam/parse_test.go
+++ b/internal/opam/parse_test.go
@@ -132,3 +132,56 @@ func TestRemoveDepFromOpam_ErrorWhenNotPresent(t *testing.T) {
 		t.Fatal("expected error when package not in depends")
 	}
 }
+
+// --- ReadOCamlVersion tests ---
+
+func TestReadOCamlVersion_GeConstraint(t *testing.T) {
+	dir := t.TempDir()
+	writeOpam(t, dir, "my_app", sampleOpam) // contains "ocaml" {>= "4.14"}
+	v, err := opam.ReadOCamlVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadOCamlVersion: %v", err)
+	}
+	if v != "4.14" {
+		t.Errorf("got %q, want %q", v, "4.14")
+	}
+}
+
+func TestReadOCamlVersion_EqConstraint(t *testing.T) {
+	dir := t.TempDir()
+	content := `opam-version: "2.0"
+depends: [
+  "ocaml" {= "5.1.0"}
+  "dune" {>= "3.0"}
+]
+`
+	writeOpam(t, dir, "my_app", content)
+	v, err := opam.ReadOCamlVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadOCamlVersion: %v", err)
+	}
+	if v != "5.1.0" {
+		t.Errorf("got %q, want %q", v, "5.1.0")
+	}
+}
+
+func TestReadOCamlVersion_MissingConstraint(t *testing.T) {
+	dir := t.TempDir()
+	content := `opam-version: "2.0"
+depends: [
+  "dune" {>= "3.0"}
+]
+`
+	writeOpam(t, dir, "my_app", content)
+	_, err := opam.ReadOCamlVersion(dir)
+	if err == nil {
+		t.Fatal("expected error when no ocaml constraint found")
+	}
+}
+
+func TestReadOCamlVersion_MissingOpamFile(t *testing.T) {
+	_, err := opam.ReadOCamlVersion(t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when no .opam file present")
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -8,56 +8,45 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-const lockFile = "oc.lock"
+const stateDir = ".oc"
+const stateFile = "state.toml"
 
-type OCamlMeta struct {
-	Version string `toml:"version"`
+// State holds machine-local oc state. It is stored in .oc/state.toml and never committed.
+type State struct {
+	SwitchPath   string `toml:"switch_path"`
+	OCamlVersion string `toml:"ocaml_version"`
 }
 
-type Package struct {
-	Name    string `toml:"name"`
-	Version string `toml:"version"`
-}
-
-// Dep represents a package name and its version constraint as parsed from CLI arguments.
-type Dep struct {
-	Name       string
-	Constraint string
-}
-
-type Lock struct {
-	OCaml      OCamlMeta `toml:"ocaml"`
-	SwitchPath string    `toml:"switch_path,omitempty"`
-	Packages   []Package `toml:"package"`
-}
-
-func LoadLock(dir string) (*Lock, error) {
-	path := filepath.Join(dir, lockFile)
+// LoadState reads .oc/state.toml. A missing file returns an empty State with no error.
+func LoadState(dir string) (State, error) {
+	path := filepath.Join(dir, stateDir, stateFile)
 	data, err := os.ReadFile(path)
 	if os.IsNotExist(err) {
-		return &Lock{}, nil
+		return State{}, nil
 	}
 	if err != nil {
-		return nil, err
+		return State{}, err
 	}
-
-	var lock Lock
-	if _, err := toml.Decode(string(data), &lock); err != nil {
-		return nil, fmt.Errorf("parse oc.lock: %w", err)
+	var s State
+	if _, err := toml.Decode(string(data), &s); err != nil {
+		return State{}, fmt.Errorf("parse .oc/state.toml: %w", err)
 	}
-	return &lock, nil
+	return s, nil
 }
 
-func SaveLock(dir string, lock *Lock) error {
-	path := filepath.Join(dir, lockFile)
-
-	tmp, err := os.CreateTemp(dir, ".oc.lock.*.tmp")
+// SaveState atomically writes .oc/state.toml, creating .oc/ if needed.
+func SaveState(dir string, s State) error {
+	ocDir := filepath.Join(dir, stateDir)
+	if err := os.MkdirAll(ocDir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(ocDir, stateFile)
+	tmp, err := os.CreateTemp(ocDir, ".state.*.tmp")
 	if err != nil {
 		return err
 	}
 	tmpPath := tmp.Name()
-
-	if err := toml.NewEncoder(tmp).Encode(lock); err != nil {
+	if err := toml.NewEncoder(tmp).Encode(s); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpPath)
 		return err
@@ -66,6 +55,11 @@ func SaveLock(dir string, lock *Lock) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-
 	return os.Rename(tmpPath, path)
+}
+
+// Dep represents a package name and its version constraint as parsed from CLI arguments.
+type Dep struct {
+	Name       string
+	Constraint string
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -5,134 +5,90 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"sync"
+	gosync "sync"
 	"testing"
 
 	"github.com/emilkloeden/oc/internal/project"
 )
 
-func TestLoadLock_Basic(t *testing.T) {
-	dir := t.TempDir()
-	content := `
-[ocaml]
-version = "5.2.0"
-
-[[package]]
-name = "cohttp"
-version = "5.0.0"
-
-[[package]]
-name = "lwt"
-version = "5.7.0"
-`
-	if err := os.WriteFile(filepath.Join(dir, "oc.lock"), []byte(content), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	lock, err := project.LoadLock(dir)
+func TestLoadState_Missing(t *testing.T) {
+	s, err := project.LoadState(t.TempDir())
 	if err != nil {
-		t.Fatalf("LoadLock: %v", err)
+		t.Fatalf("LoadState missing file should return empty State, got error: %v", err)
 	}
-	if lock.OCaml.Version != "5.2.0" {
-		t.Errorf("ocaml version: got %q", lock.OCaml.Version)
+	if s.SwitchPath != "" {
+		t.Errorf("expected empty SwitchPath, got %q", s.SwitchPath)
 	}
-	if len(lock.Packages) != 2 {
-		t.Fatalf("expected 2 packages, got %d", len(lock.Packages))
-	}
-	if lock.Packages[0].Name != "cohttp" || lock.Packages[0].Version != "5.0.0" {
-		t.Errorf("package[0]: %+v", lock.Packages[0])
+	if s.OCamlVersion != "" {
+		t.Errorf("expected empty OCamlVersion, got %q", s.OCamlVersion)
 	}
 }
 
-func TestLoadLock_Missing(t *testing.T) {
-	lock, err := project.LoadLock(t.TempDir())
+func TestSaveState_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := project.State{
+		SwitchPath:   "/cache/oc/switches/abc123/",
+		OCamlVersion: "5.2.0",
+	}
+	if err := project.SaveState(dir, s); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	got, err := project.LoadState(dir)
 	if err != nil {
-		t.Fatalf("LoadLock missing file should return empty lock, got error: %v", err)
+		t.Fatalf("LoadState: %v", err)
 	}
-	if len(lock.Packages) != 0 {
-		t.Errorf("expected empty packages, got %v", lock.Packages)
+	if got.SwitchPath != s.SwitchPath {
+		t.Errorf("SwitchPath: got %q, want %q", got.SwitchPath, s.SwitchPath)
 	}
-}
-
-func TestLoadLock_CorruptedFile(t *testing.T) {
-	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "oc.lock"), []byte("NOT VALID TOML ][[["), 0644); err != nil {
-		t.Fatal(err)
-	}
-	lock, err := project.LoadLock(dir)
-	if err == nil {
-		t.Fatal("expected error for corrupted oc.lock, got nil")
-	}
-	if lock != nil {
-		t.Errorf("expected nil lock on error, got %+v", lock)
+	if got.OCamlVersion != s.OCamlVersion {
+		t.Errorf("OCamlVersion: got %q, want %q", got.OCamlVersion, s.OCamlVersion)
 	}
 }
 
-func TestSaveLock_NoTempFilesLeftOnSuccess(t *testing.T) {
+func TestSaveState_CreatesOCDirectory(t *testing.T) {
 	dir := t.TempDir()
-	lock := &project.Lock{OCaml: project.OCamlMeta{Version: "5.2.0"}}
-	if err := project.SaveLock(dir, lock); err != nil {
-		t.Fatal(err)
+	if err := project.SaveState(dir, project.State{SwitchPath: "/tmp/sw"}); err != nil {
+		t.Fatalf("SaveState: %v", err)
 	}
+	if _, err := os.Stat(filepath.Join(dir, ".oc")); err != nil {
+		t.Errorf(".oc directory not created: %v", err)
+	}
+}
 
-	entries, err := os.ReadDir(dir)
+func TestSaveState_NoTempFilesLeft(t *testing.T) {
+	dir := t.TempDir()
+	if err := project.SaveState(dir, project.State{SwitchPath: "/tmp/sw"}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	entries, err := os.ReadDir(filepath.Join(dir, ".oc"))
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, e := range entries {
-		if strings.HasPrefix(e.Name(), ".oc.lock.") && strings.HasSuffix(e.Name(), ".tmp") {
-			t.Errorf("temp file left behind after SaveLock: %s", e.Name())
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
 		}
 	}
 }
 
-func TestSaveLock_ConcurrentWritesProduceValidFile(t *testing.T) {
+func TestSaveState_ConcurrentWritesProduceValidFile(t *testing.T) {
 	dir := t.TempDir()
-
 	const goroutines = 50
-	var wg sync.WaitGroup
+	var wg gosync.WaitGroup
 	wg.Add(goroutines)
-
 	for i := 0; i < goroutines; i++ {
 		i := i
 		go func() {
 			defer wg.Done()
-			lock := &project.Lock{
-				OCaml:      project.OCamlMeta{Version: "5.2.0"},
-				SwitchPath: fmt.Sprintf("/path/to/switch/%d", i),
-				Packages:   []project.Package{{Name: "pkg", Version: fmt.Sprintf("1.0.%d", i)}},
-			}
-			_ = project.SaveLock(dir, lock)
+			_ = project.SaveState(dir, project.State{
+				SwitchPath:   fmt.Sprintf("/path/%d", i),
+				OCamlVersion: "5.2.0",
+			})
 		}()
 	}
 	wg.Wait()
-
-	_, err := project.LoadLock(dir)
+	_, err := project.LoadState(dir)
 	if err != nil {
-		t.Errorf("after concurrent SaveLock, oc.lock is not parseable: %v", err)
-	}
-}
-
-func TestSaveLock_RoundTrip(t *testing.T) {
-	dir := t.TempDir()
-	lock := &project.Lock{
-		OCaml: project.OCamlMeta{Version: "5.2.0"},
-		Packages: []project.Package{
-			{Name: "cohttp", Version: "5.0.0"},
-			{Name: "lwt", Version: "5.7.0"},
-		},
-	}
-	if err := project.SaveLock(dir, lock); err != nil {
-		t.Fatalf("SaveLock: %v", err)
-	}
-	got, err := project.LoadLock(dir)
-	if err != nil {
-		t.Fatalf("LoadLock: %v", err)
-	}
-	if len(got.Packages) != 2 {
-		t.Fatalf("expected 2 packages, got %d", len(got.Packages))
-	}
-	if got.Packages[1].Name != "lwt" {
-		t.Errorf("package[1]: %+v", got.Packages[1])
+		t.Errorf("after concurrent SaveState, state.toml is not parseable: %v", err)
 	}
 }

--- a/internal/switch/switch.go
+++ b/internal/switch/switch.go
@@ -5,32 +5,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
-
-	"github.com/emilkloeden/oc/internal/project"
 )
 
-func Hash(lock *project.Lock) string {
-	pkgs := make([]project.Package, len(lock.Packages))
-	copy(pkgs, lock.Packages)
-	sort.Slice(pkgs, func(i, j int) bool {
-		if pkgs[i].Name != pkgs[j].Name {
-			return pkgs[i].Name < pkgs[j].Name
-		}
-		return pkgs[i].Version < pkgs[j].Version
-	})
-
-	h := sha256.New()
-	fmt.Fprintf(h, "ocaml=%s\n", lock.OCaml.Version)
-	for _, p := range pkgs {
-		fmt.Fprintf(h, "%s=%s\n", p.Name, p.Version)
-	}
-	return fmt.Sprintf("%x", h.Sum(nil))[:16]
-}
-
-func CachePath(lock *project.Lock) string {
+// CachePathForVersion returns the content-addressed switch path for the given OCaml version.
+// All projects using the same OCaml version share the same switch (dependencies accumulate via opam).
+func CachePathForVersion(ocamlVersion string) string {
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".cache", "oc", "switches", Hash(lock))
+	h := sha256.New()
+	fmt.Fprintf(h, "ocaml=%s\n", ocamlVersion)
+	hash := fmt.Sprintf("%x", h.Sum(nil))[:16]
+	return filepath.Join(home, ".cache", "oc", "switches", hash)
 }
 
 func EnsureSymlink(projectDir, target string) error {

--- a/internal/switch/switch_test.go
+++ b/internal/switch/switch_test.go
@@ -7,70 +7,38 @@ import (
 	"testing"
 
 	sw "github.com/emilkloeden/oc/internal/switch"
-	"github.com/emilkloeden/oc/internal/project"
 )
 
-func lock(ocamlVer string, pkgs ...project.Package) *project.Lock {
-	return &project.Lock{
-		OCaml:    project.OCamlMeta{Version: ocamlVer},
-		Packages: pkgs,
+func TestCachePathForVersion_Deterministic(t *testing.T) {
+	p1 := sw.CachePathForVersion("5.2.0")
+	p2 := sw.CachePathForVersion("5.2.0")
+	if p1 != p2 {
+		t.Errorf("CachePathForVersion not deterministic: %q vs %q", p1, p2)
 	}
 }
 
-func TestHash_DeterministicSameInputs(t *testing.T) {
-	l := lock("5.2.0",
-		project.Package{Name: "cohttp", Version: "5.0.0"},
-		project.Package{Name: "lwt", Version: "5.7.0"},
-	)
-	h1 := sw.Hash(l)
-	h2 := sw.Hash(l)
-	if h1 != h2 {
-		t.Errorf("hash not deterministic: %q vs %q", h1, h2)
+func TestCachePathForVersion_DiffersForDifferentVersions(t *testing.T) {
+	p1 := sw.CachePathForVersion("5.2.0")
+	p2 := sw.CachePathForVersion("5.3.0")
+	if p1 == p2 {
+		t.Error("different OCaml versions should produce different cache paths")
 	}
 }
 
-func TestHash_DifferentOCamlVersion(t *testing.T) {
-	l1 := lock("5.2.0", project.Package{Name: "cohttp", Version: "5.0.0"})
-	l2 := lock("5.1.0", project.Package{Name: "cohttp", Version: "5.0.0"})
-	if sw.Hash(l1) == sw.Hash(l2) {
-		t.Error("different ocaml versions should produce different hashes")
+func TestCachePathForVersion_ContainsExpectedSegments(t *testing.T) {
+	path := sw.CachePathForVersion("5.2.0")
+	if !strings.Contains(path, filepath.Join(".cache", "oc", "switches")) {
+		t.Errorf("unexpected path structure: %q", path)
 	}
-}
-
-func TestHash_DifferentPackages(t *testing.T) {
-	l1 := lock("5.2.0", project.Package{Name: "cohttp", Version: "5.0.0"})
-	l2 := lock("5.2.0", project.Package{Name: "cohttp", Version: "5.1.0"})
-	if sw.Hash(l1) == sw.Hash(l2) {
-		t.Error("different package versions should produce different hashes")
-	}
-}
-
-func TestHash_OrderIndependent(t *testing.T) {
-	l1 := lock("5.2.0",
-		project.Package{Name: "cohttp", Version: "5.0.0"},
-		project.Package{Name: "lwt", Version: "5.7.0"},
-	)
-	l2 := lock("5.2.0",
-		project.Package{Name: "lwt", Version: "5.7.0"},
-		project.Package{Name: "cohttp", Version: "5.0.0"},
-	)
-	if sw.Hash(l1) != sw.Hash(l2) {
-		t.Error("package order should not affect hash")
-	}
-}
-
-func TestCachePath_ContainsHash(t *testing.T) {
-	l := lock("5.2.0", project.Package{Name: "cohttp", Version: "5.0.0"})
-	h := sw.Hash(l)
-	path := sw.CachePath(l)
-	if filepath.Base(path) != h {
-		t.Errorf("CachePath base should be hash %q, got %q", h, filepath.Base(path))
+	base := filepath.Base(path)
+	if len(base) != 16 {
+		t.Errorf("expected 16-char hash in path base, got %q (len %d)", base, len(base))
 	}
 }
 
 func TestEnsureSymlink_CreatesLink(t *testing.T) {
 	projectDir := t.TempDir()
-	target := t.TempDir() // simulates a switch directory that already exists
+	target := t.TempDir()
 
 	if err := sw.EnsureSymlink(projectDir, target); err != nil {
 		t.Fatalf("EnsureSymlink: %v", err)
@@ -98,7 +66,6 @@ func TestEnsureSymlink_UpdatesStaleLink(t *testing.T) {
 	old := t.TempDir()
 	newTarget := t.TempDir()
 
-	// create initial symlink
 	if err := os.Symlink(old, filepath.Join(projectDir, ".ocaml")); err != nil {
 		t.Fatal(err)
 	}
@@ -116,7 +83,6 @@ func TestEnsureSymlink_UpdatesStaleLink(t *testing.T) {
 func TestEnsureSymlink_RegularFileReturnsError(t *testing.T) {
 	projectDir := t.TempDir()
 	link := filepath.Join(projectDir, ".ocaml")
-	// Create a regular file (not a symlink) at .ocaml
 	if err := os.WriteFile(link, []byte("not a symlink"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -126,14 +92,13 @@ func TestEnsureSymlink_RegularFileReturnsError(t *testing.T) {
 		t.Fatal("expected error when .ocaml is a regular file, got nil")
 	}
 	if !strings.Contains(err.Error(), "remove it manually") {
-		t.Errorf("error should mention 'remove it manually' to guide the user; got: %v", err)
+		t.Errorf("error should mention 'remove it manually'; got: %v", err)
 	}
 }
 
 func TestEnsureSymlink_DirectoryReturnsError(t *testing.T) {
 	projectDir := t.TempDir()
 	link := filepath.Join(projectDir, ".ocaml")
-	// Create a directory at .ocaml
 	if err := os.MkdirAll(link, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -143,6 +108,6 @@ func TestEnsureSymlink_DirectoryReturnsError(t *testing.T) {
 		t.Fatal("expected error when .ocaml is a directory, got nil")
 	}
 	if !strings.Contains(err.Error(), "remove it manually") {
-		t.Errorf("error should mention 'remove it manually' to guide the user; got: %v", err)
+		t.Errorf("error should mention 'remove it manually'; got: %v", err)
 	}
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -1,10 +1,8 @@
 package sync
 
 import (
-	"bytes"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/emilkloeden/oc/internal/exec"
 	"github.com/emilkloeden/oc/internal/opam"
@@ -18,7 +16,7 @@ type OpamRunner interface {
 	SwitchExists(path string) bool
 	CreateSwitch(path, ocamlVersion string) error
 	InstallDeps(dir, switchPath string) error
-	ListInstalled(switchPath string) ([]project.Package, error)
+	LockDeps(dir string) error
 }
 
 type realRunner struct{}
@@ -45,42 +43,18 @@ func (r *realRunner) InstallDeps(dir, switchPath string) error {
 	}, exec.Options{Dir: dir})
 }
 
-func (r *realRunner) ListInstalled(switchPath string) ([]project.Package, error) {
-	var buf bytes.Buffer
-	err := exec.Run("opam", []string{
-		"list", "--installed", "--short",
-		"--columns=name,version",
-		"--switch", switchPath,
-	}, exec.Options{Stdout: &buf})
-	if err != nil {
-		return nil, err
-	}
-
-	var pkgs []project.Package
-	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.Fields(line)
-		if len(parts) >= 2 {
-			pkgs = append(pkgs, project.Package{Name: parts[0], Version: parts[1]})
-		}
-	}
-	return pkgs, nil
+func (r *realRunner) LockDeps(dir string) error {
+	return exec.Run("opam", []string{"lock", "."}, exec.Options{Dir: dir})
 }
 
 // Ensure is the public entry point using the real opam runner.
-// It reads the OCaml version from oc.lock, defaulting to 5.2.0 if absent.
+// It reads the OCaml version from the .opam file, defaulting to 5.2.0 if absent.
 func Ensure(dir string) error {
 	if err := opam.CheckOpam(); err != nil {
 		return err
 	}
-	lock, err := project.LoadLock(dir)
+	ocamlVersion, err := opam.ReadOCamlVersion(dir)
 	if err != nil {
-		return fmt.Errorf("load lockfile: %w", err)
-	}
-	ocamlVersion := lock.OCaml.Version
-	if ocamlVersion == "" {
 		ocamlVersion = defaultOCamlVersion
 	}
 	return EnsureWith(dir, ocamlVersion, &realRunner{})
@@ -88,22 +62,20 @@ func Ensure(dir string) error {
 
 // EnsureWith allows injection of a custom runner (used in tests).
 func EnsureWith(dir string, ocamlVersion string, runner OpamRunner) error {
-	lock, err := project.LoadLock(dir)
+	state, err := project.LoadState(dir)
 	if err != nil {
-		return fmt.Errorf("load lockfile: %w", err)
+		return fmt.Errorf("load state: %w", err)
 	}
-	// Detect OCaml version change — stale switch path must be discarded.
-	if lock.OCaml.Version != "" && lock.OCaml.Version != ocamlVersion {
-		lock.SwitchPath = ""
-	}
-	lock.OCaml.Version = ocamlVersion
 
-	// Use the stored switch path if present and the switch still exists there.
-	// This keeps the path stable even after the lock is populated with packages
-	// (which would change the content-addressed hash).
-	switchPath := lock.SwitchPath
+	// Detect OCaml version change — discard stale switch path.
+	if state.OCamlVersion != "" && state.OCamlVersion != ocamlVersion {
+		state.SwitchPath = ""
+	}
+	state.OCamlVersion = ocamlVersion
+
+	switchPath := state.SwitchPath
 	if switchPath == "" || !runner.SwitchExists(switchPath) {
-		switchPath = swmgr.CachePath(lock)
+		switchPath = swmgr.CachePathForVersion(ocamlVersion)
 	}
 
 	if !runner.SwitchExists(switchPath) {
@@ -120,15 +92,14 @@ func EnsureWith(dir string, ocamlVersion string, runner OpamRunner) error {
 		return fmt.Errorf("install deps: %w", err)
 	}
 
-	pkgs, err := runner.ListInstalled(switchPath)
-	if err != nil {
-		return fmt.Errorf("list installed: %w", err)
+	state.SwitchPath = switchPath
+	if err := project.SaveState(dir, state); err != nil {
+		return fmt.Errorf("save state: %w", err)
 	}
 
-	lock.SwitchPath = switchPath
-	lock.Packages = pkgs
-	if err := project.SaveLock(dir, lock); err != nil {
-		return fmt.Errorf("save lockfile: %w", err)
+	// Generate *.opam.locked after successful install. Failure is non-fatal.
+	if err := runner.LockDeps(dir); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: opam lock failed: %v\n", err)
 	}
 
 	return nil

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -11,12 +11,12 @@ import (
 )
 
 type mockRunner struct {
-	switches        map[string]bool
-	createCalled    []string
-	installCalled   []string
-	installedPkgs   []project.Package
-	createErr       error
-	installErr      error
+	switches      map[string]bool
+	createCalled  []string
+	installCalled []string
+	lockCalled    []string
+	createErr     error
+	installErr    error
 }
 
 func (m *mockRunner) SwitchExists(path string) bool {
@@ -34,8 +34,9 @@ func (m *mockRunner) InstallDeps(dir, switchPath string) error {
 	return m.installErr
 }
 
-func (m *mockRunner) ListInstalled(switchPath string) ([]project.Package, error) {
-	return m.installedPkgs, nil
+func (m *mockRunner) LockDeps(dir string) error {
+	m.lockCalled = append(m.lockCalled, dir)
+	return nil
 }
 
 func TestEnsureWith_CreatesSwitch_WhenMissing(t *testing.T) {
@@ -100,33 +101,7 @@ func TestEnsureWith_CallsInstallDeps(t *testing.T) {
 	}
 }
 
-func TestEnsureWith_UpdatesLockfile(t *testing.T) {
-	dir := t.TempDir()
-	runner := &mockRunner{
-		switches: map[string]bool{},
-		installedPkgs: []project.Package{
-			{Name: "cohttp", Version: "5.0.0"},
-			{Name: "lwt", Version: "5.7.0"},
-		},
-	}
-
-	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
-		t.Fatalf("EnsureWith: %v", err)
-	}
-
-	lock, err := project.LoadLock(dir)
-	if err != nil {
-		t.Fatalf("LoadLock: %v", err)
-	}
-	if len(lock.Packages) != 2 {
-		t.Errorf("expected 2 packages in lockfile, got %d", len(lock.Packages))
-	}
-	if lock.OCaml.Version != "5.2.0" {
-		t.Errorf("ocaml version in lock: got %q", lock.OCaml.Version)
-	}
-}
-
-func TestEnsureWith_StoresSwitchPathInLock(t *testing.T) {
+func TestEnsureWith_CallsLockDeps(t *testing.T) {
 	dir := t.TempDir()
 	runner := &mockRunner{switches: map[string]bool{}}
 
@@ -134,39 +109,48 @@ func TestEnsureWith_StoresSwitchPathInLock(t *testing.T) {
 		t.Fatalf("EnsureWith: %v", err)
 	}
 
-	lock, err := project.LoadLock(dir)
-	if err != nil {
-		t.Fatalf("LoadLock: %v", err)
+	if len(runner.lockCalled) != 1 {
+		t.Errorf("expected LockDeps called once, got %d", len(runner.lockCalled))
 	}
-	if lock.SwitchPath == "" {
-		t.Error("expected SwitchPath to be stored in lockfile")
+}
+
+func TestEnsureWith_SavesState(t *testing.T) {
+	dir := t.TempDir()
+	runner := &mockRunner{switches: map[string]bool{}}
+
+	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
+		t.Fatalf("EnsureWith: %v", err)
+	}
+
+	s, err := project.LoadState(dir)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if s.SwitchPath == "" {
+		t.Error("expected SwitchPath to be saved in state")
+	}
+	if s.OCamlVersion != "5.2.0" {
+		t.Errorf("OCamlVersion in state: got %q, want %q", s.OCamlVersion, "5.2.0")
 	}
 }
 
 func TestEnsureWith_ReusesSwitchPathAcrossCalls(t *testing.T) {
 	dir := t.TempDir()
-	runner := &mockRunner{
-		switches: map[string]bool{},
-		installedPkgs: []project.Package{
-			{Name: "cohttp", Version: "5.0.0"},
-		},
-	}
+	runner := &mockRunner{switches: map[string]bool{}}
 
-	// First call: switch created, lock written with packages + switch path
+	// First call: switch created, state written with switch path
 	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
 		t.Fatal(err)
 	}
+	s1, _ := project.LoadState(dir)
+	path1 := s1.SwitchPath
 
-	lock1, _ := project.LoadLock(dir)
-	path1 := lock1.SwitchPath
-
-	// Second call: packages now in lock → hash would differ without stored path
+	// Second call: should reuse stored path, not recompute
 	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
 		t.Fatal(err)
 	}
-
-	lock2, _ := project.LoadLock(dir)
-	path2 := lock2.SwitchPath
+	s2, _ := project.LoadState(dir)
+	path2 := s2.SwitchPath
 
 	if path1 != path2 {
 		t.Errorf("switch path changed between calls: %q → %q", path1, path2)
@@ -202,7 +186,7 @@ func TestEnsureWith_NewSwitchOnOCamlVersionChange(t *testing.T) {
 	}
 	path1 := runner.createCalled[0]
 
-	// Second call with a different OCaml version
+	// Second call with a different OCaml version — stored path must be discarded
 	if err := sync.EnsureWith(dir, "5.3.0", runner); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary

- Removes the custom `oc.lock` format (no other tooling could read it)
- Adds `.oc/state.toml` (gitignored, machine-local) storing only `switch_path` and `ocaml_version`
- `*.opam.locked` (committed) is now generated by `opam lock .` after each install, giving experienced opam users a native lockfile they can use with `opam install --locked`
- OCaml version is read from the `.opam` file's `depends:` block (`ReadOCamlVersion`) rather than stored in a custom file
- Switch hash simplified to `CachePathForVersion(ocamlVersion)` — no more package list in the hash
- Silent one-time migration: if `oc.lock` exists but `.oc/state.toml` does not, `switch_path` is copied across and `oc.lock` is deleted

Closes #46, #47, #48, #49, #50, #51

## Test plan

- [x] `go test ./...` passes (all unit tests green)
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Integration tests (`go test -tags integration -timeout 20m .`) — requires opam
- [ ] Manual: `oc new`, `oc add`, `oc build` — verify `.oc/state.toml` created, no `oc.lock`
- [ ] Migration: create a project with old `oc.lock`, run `oc build`, verify `oc.lock` deleted and `.oc/state.toml` created

🤖 Generated with [Claude Code](https://claude.com/claude-code)