### PR TITLE
fix: eliminate double findOpamDepsBounds call in ReadOCamlVersion

### DIFF
--- a/internal/opam/parse.go
+++ b/internal/opam/parse.go
@@ -156,12 +156,10 @@ func ReadOCamlVersion(dir string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read opam file: %w", err)
 	}
-	_, end, err := findOpamDepsBounds(string(data))
+	start, end, err := findOpamDepsBounds(string(data))
 	if err != nil {
 		return "", fmt.Errorf("find depends block: %w", err)
 	}
-	// start is index after "depends: ["; search only inside the block
-	start, _, _ := findOpamDepsBounds(string(data))
 	block := string(data)[start:end]
 	for _, line := range strings.Split(block, "\n") {
 		trimmed := strings.TrimSpace(line)

--- a/internal/opam/parse_test.go
+++ b/internal/opam/parse_test.go
@@ -185,3 +185,28 @@ func TestReadOCamlVersion_MissingOpamFile(t *testing.T) {
 		t.Fatal("expected error when no .opam file present")
 	}
 }
+
+func TestReadOCamlVersion_ReadsFromDependsBlockOnly(t *testing.T) {
+	// Verify the function scans only the depends block, not the full file.
+	// A file with depopts before depends: the depopts block ends with ']' before
+	// depends: opens. If start were incorrectly 0 the scanner would include content
+	// from before the depends block.
+	dir := t.TempDir()
+	content := `opam-version: "2.0"
+depopts: [
+  "threads" {>= "0.1"}
+]
+depends: [
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "3.0"}
+]
+`
+	writeOpam(t, dir, "my_app", content)
+	v, err := opam.ReadOCamlVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadOCamlVersion: %v", err)
+	}
+	if v != "5.2.0" {
+		t.Errorf("got %q, want %q", v, "5.2.0")
+	}
+}


### PR DESCRIPTION
## Summary

- `ReadOCamlVersion` called `findOpamDepsBounds` twice on the same string; the second call silenced its error (`_, _`), meaning any failure would silently set `start=0` and cause the version scan to include content before the `depends:` block
- Combined into a single `start, end, err := findOpamDepsBounds(...)` call

## Test plan
- [ ] `go test ./internal/opam/...` — all pass including new `TestReadOCamlVersion_ReadsFromDependsBlockOnly`

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)