### PR TITLE
refactor: replace _ = start with blank identifier in AddDepToOpam

### DIFF
--- a/internal/opam/parse.go
+++ b/internal/opam/parse.go
@@ -45,11 +45,10 @@ func AddDepToOpam(path, pkg, constraint string) error {
 	entry := formatOpamDepEntry(pkg, constraint)
 
 	// Find the closing ']' of the depends: block and insert before it
-	start, end, err := findOpamDepsBounds(content)
+	_, end, err := findOpamDepsBounds(content)
 	if err != nil {
 		return err
 	}
-	_ = start
 
 	newContent := content[:end] + "  " + entry + "\n" + content[end:]
 	return os.WriteFile(path, []byte(newContent), 0644)

--- a/internal/opam/parse_test.go
+++ b/internal/opam/parse_test.go
@@ -186,6 +186,29 @@ func TestReadOCamlVersion_MissingOpamFile(t *testing.T) {
 	}
 }
 
+func TestAddDepToOpam_InsertsInsideDependsBlockNotAtFileStart(t *testing.T) {
+	// Ensures insertion uses the correct block bounds (end position),
+	// not position 0 (which would prepend before the file header).
+	dir := t.TempDir()
+	content := `opam-version: "2.0"
+name: "my_app"
+depends: [
+  "dune" {>= "3.0"}
+]
+`
+	path := writeOpam(t, dir, "my_app", content)
+	if err := opam.AddDepToOpam(path, "yojson", "*"); err != nil {
+		t.Fatalf("AddDepToOpam: %v", err)
+	}
+	result, _ := os.ReadFile(path)
+	// yojson must appear inside the depends block, after the opening "["
+	depIdx := strings.Index(string(result), `"yojson"`)
+	dependsIdx := strings.Index(string(result), "depends: [")
+	if depIdx < dependsIdx {
+		t.Errorf("yojson was inserted before the depends block (depIdx=%d < dependsIdx=%d)", depIdx, dependsIdx)
+	}
+}
+
 func TestReadOCamlVersion_ReadsFromDependsBlockOnly(t *testing.T) {
 	// Verify the function scans only the depends block, not the full file.
 	// A file with depopts before depends: the depopts block ends with ']' before


### PR DESCRIPTION
## Summary

- `AddDepToOpam` assigned `start` from `findOpamDepsBounds` then immediately discarded it with `_ = start`, which looks like a latent bug to reviewers
- Changed to `_, end, err := findOpamDepsBounds(content)` to express intent clearly

## Test plan
- [ ] `go test ./internal/opam/...` — all pass including new `TestAddDepToOpam_InsertsInsideDependsBlockNotAtFileStart`

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)