### PR TITLE
refactor: extract DefaultOCamlVersion to internal/defaults

### DIFF
--- a/internal/defaults/defaults.go
+++ b/internal/defaults/defaults.go
@@ -1,0 +1,3 @@
+package defaults
+
+const DefaultOCamlVersion = "5.2.0"

--- a/internal/defaults/defaults_test.go
+++ b/internal/defaults/defaults_test.go
@@ -1,0 +1,22 @@
+package defaults_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/emilkloeden/oc/internal/defaults"
+)
+
+func TestDefaultOCamlVersion_IsSet(t *testing.T) {
+	if defaults.DefaultOCamlVersion == "" {
+		t.Fatal("DefaultOCamlVersion must not be empty")
+	}
+}
+
+func TestDefaultOCamlVersion_IsSemver(t *testing.T) {
+	v := defaults.DefaultOCamlVersion
+	parts := strings.Split(v, ".")
+	if len(parts) < 2 {
+		t.Errorf("DefaultOCamlVersion %q does not look like a semver (expected at least MAJOR.MINOR)", v)
+	}
+}

--- a/internal/dune/dune.go
+++ b/internal/dune/dune.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/emilkloeden/oc/internal/defaults"
 )
 
 const duneVersion = "3.0"
-const defaultOCamlVersion = "5.2.0"
 
 func ScaffoldBin(dir, name, maintainer string) error {
 	if err := writeIfAbsent(filepath.Join(dir, "dune-project"), duneProject(name, maintainer)); err != nil {
@@ -56,7 +57,7 @@ func duneProject(name, maintainer string) string {
  (depends
   (ocaml (>= %q))
   dune))
-`, duneVersion, name, maintainer, maintainer, defaultOCamlVersion)
+`, duneVersion, name, maintainer, maintainer, defaults.DefaultOCamlVersion)
 }
 
 func binDune(name string) string {

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/emilkloeden/oc/internal/defaults"
 	"github.com/emilkloeden/oc/internal/exec"
 	"github.com/emilkloeden/oc/internal/opam"
 	"github.com/emilkloeden/oc/internal/project"
 	swmgr "github.com/emilkloeden/oc/internal/switch"
 )
-
-const defaultOCamlVersion = "5.2.0"
 
 type OpamRunner interface {
 	SwitchExists(path string) bool
@@ -55,7 +54,7 @@ func Ensure(dir string) error {
 	}
 	ocamlVersion, err := opam.ReadOCamlVersion(dir)
 	if err != nil {
-		ocamlVersion = defaultOCamlVersion
+		ocamlVersion = defaults.DefaultOCamlVersion
 	}
 	return EnsureWith(dir, ocamlVersion, &realRunner{})
 }


### PR DESCRIPTION
## Summary

- `"5.2.0"` was hardcoded separately in `internal/dune/dune.go` and `internal/sync/sync.go`
- Extracted to `internal/defaults.DefaultOCamlVersion`; both consumers import it

## Test plan
- [ ] `go test ./...` — all pass including new `internal/defaults` package tests

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)