### PR TITLE
refactor: extract parseConstraintParts to internal/project

### DIFF
--- a/internal/dune/parse.go
+++ b/internal/dune/parse.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/emilkloeden/oc/internal/project"
 )
 
 // HasGenerateOpamFiles reports whether dune-project in dir contains (generate_opam_files true).
@@ -402,19 +404,9 @@ func formatDuneDepEntry(pkg, constraint string) string {
 	if constraint == "*" || constraint == "" {
 		return pkg
 	}
-	op, ver := parseConstraintParts(constraint)
+	op, ver := project.ParseConstraintParts(constraint)
 	if op == "" {
 		return pkg
 	}
 	return fmt.Sprintf("(%s (%s %q))", pkg, op, ver)
-}
-
-// parseConstraintParts splits a constraint like ">=5.0.0" into op=">=", ver="5.0.0".
-func parseConstraintParts(c string) (op, ver string) {
-	for _, prefix := range []string{">=", "<=", ">", "<", "="} {
-		if strings.HasPrefix(c, prefix) {
-			return prefix, strings.TrimSpace(c[len(prefix):])
-		}
-	}
-	return "", c
 }

--- a/internal/opam/parse.go
+++ b/internal/opam/parse.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/emilkloeden/oc/internal/project"
 )
 
 // FindOpamFile returns the path to the single *.opam file in dir.
@@ -127,21 +129,11 @@ func formatOpamDepEntry(pkg, constraint string) string {
 	if constraint == "*" || constraint == "" {
 		return fmt.Sprintf("%q", pkg)
 	}
-	op, ver := parseConstraintParts(constraint)
+	op, ver := project.ParseConstraintParts(constraint)
 	if op == "" {
 		return fmt.Sprintf("%q", pkg)
 	}
 	return fmt.Sprintf("%q {%s %q}", pkg, op, ver)
-}
-
-// parseConstraintParts splits a constraint like ">=5.0.0" into op=">=", ver="5.0.0".
-func parseConstraintParts(c string) (op, ver string) {
-	for _, prefix := range []string{">=", "<=", ">", "<", "="} {
-		if strings.HasPrefix(c, prefix) {
-			return prefix, strings.TrimSpace(c[len(prefix):])
-		}
-	}
-	return "", c
 }
 
 // ReadOCamlVersion reads the OCaml version constraint from the .opam file in dir.

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -62,4 +63,15 @@ func SaveState(dir string, s State) error {
 type Dep struct {
 	Name       string
 	Constraint string
+}
+
+// ParseConstraintParts splits a constraint like ">=5.0.0" into op=">=", ver="5.0.0".
+// Returns op="" if no recognised operator prefix is found.
+func ParseConstraintParts(c string) (op, ver string) {
+	for _, prefix := range []string{">=", "<=", ">", "<", "="} {
+		if strings.HasPrefix(c, prefix) {
+			return prefix, strings.TrimSpace(c[len(prefix):])
+		}
+	}
+	return "", c
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -92,3 +92,41 @@ func TestSaveState_ConcurrentWritesProduceValidFile(t *testing.T) {
 		t.Errorf("after concurrent SaveState, state.toml is not parseable: %v", err)
 	}
 }
+
+func TestParseConstraintParts_GEOperator(t *testing.T) {
+	op, ver := project.ParseConstraintParts(">=5.2.0")
+	if op != ">=" || ver != "5.2.0" {
+		t.Errorf("got op=%q ver=%q, want op=\">=\" ver=\"5.2.0\"", op, ver)
+	}
+}
+
+func TestParseConstraintParts_LEOperator(t *testing.T) {
+	op, ver := project.ParseConstraintParts("<=2.0")
+	if op != "<=" || ver != "2.0" {
+		t.Errorf("got op=%q ver=%q, want op=\"<=\" ver=\"2.0\"", op, ver)
+	}
+}
+
+func TestParseConstraintParts_EqOperator(t *testing.T) {
+	op, ver := project.ParseConstraintParts("=1.0.0")
+	if op != "=" || ver != "1.0.0" {
+		t.Errorf("got op=%q ver=%q, want op=\"=\" ver=\"1.0.0\"", op, ver)
+	}
+}
+
+func TestParseConstraintParts_NoOperator(t *testing.T) {
+	op, ver := project.ParseConstraintParts("someversion")
+	if op != "" {
+		t.Errorf("got op=%q, want empty", op)
+	}
+	if ver != "someversion" {
+		t.Errorf("got ver=%q, want %q", ver, "someversion")
+	}
+}
+
+func TestParseConstraintParts_Wildcard(t *testing.T) {
+	op, ver := project.ParseConstraintParts("*")
+	if op != "" || ver != "*" {
+		t.Errorf("got op=%q ver=%q, want op=\"\" ver=\"*\"", op, ver)
+	}
+}


### PR DESCRIPTION
## Summary

- `parseConstraintParts` was defined identically in `internal/dune/parse.go` and `internal/opam/parse.go`
- Moved to `project.ParseConstraintParts` (exported) alongside `project.Dep`, the type whose `Constraint` field it operates on
- Both `dune` and `opam` packages now import and use the shared function

## Test plan
- [ ] `go test ./...` — all pass including new `TestParseConstraintParts_*` tests in `internal/project`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)