### PR TITLE
feat: export RunAdd and add unit tests for oc add flow

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -28,7 +28,7 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		if err := runAdd(dir, deps, addDev); err != nil {
+		if err := runAdd(dir, deps, addDev, sync.Ensure); err != nil {
 			return err
 		}
 
@@ -40,7 +40,7 @@ var addCmd = &cobra.Command{
 }
 
 // runAdd adds deps to the project manifest and syncs.
-func runAdd(dir string, deps []project.Dep, dev bool) error {
+func runAdd(dir string, deps []project.Dep, dev bool, syncFn func(string) error) error {
 	pt, err := project.Detect(dir)
 	if err != nil {
 		return err
@@ -63,7 +63,7 @@ func runAdd(dir string, deps []project.Dep, dev bool) error {
 		}
 	}
 
-	if err := sync.Ensure(dir); err != nil {
+	if err := syncFn(dir); err != nil {
 		return fmt.Errorf("sync: %w", err)
 	}
 	return nil

--- a/cmd/add_unit_test.go
+++ b/cmd/add_unit_test.go
@@ -1,0 +1,126 @@
+package cmd_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/emilkloeden/oc/cmd"
+	"github.com/emilkloeden/oc/internal/project"
+)
+
+const addTestDuneProject = `(lang dune 3.0)
+(generate_opam_files true)
+
+(package
+ (name my_app)
+ (synopsis "test")
+ (depends
+  (ocaml (>= "5.2.0"))
+  dune))
+`
+
+const addTestOpamFile = `opam-version: "2.0"
+name: "my_app"
+depends: [
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "3.0"}
+]
+`
+
+func noopSync(_ string) error { return nil }
+
+func TestRunAdd_DuneManagedProject_AddsToduneProject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dune-project"), []byte(addTestDuneProject), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
+	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+		t.Fatalf("RunAdd: %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(dir, "dune-project"))
+	if !strings.Contains(string(content), "yojson") {
+		t.Errorf("expected yojson in dune-project:\n%s", content)
+	}
+}
+
+func TestRunAdd_DuneManagedProject_AddsWithConstraint(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dune-project"), []byte(addTestDuneProject), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := []project.Dep{{Name: "cohttp", Constraint: ">=5.0.0"}}
+	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+		t.Fatalf("RunAdd: %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(dir, "dune-project"))
+	if !strings.Contains(string(content), "cohttp") || !strings.Contains(string(content), "5.0.0") {
+		t.Errorf("expected cohttp with constraint in dune-project:\n%s", content)
+	}
+}
+
+func TestRunAdd_HandWrittenOpam_AddsToOpamFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "my_app.opam"), []byte(addTestOpamFile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
+	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+		t.Fatalf("RunAdd: %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(dir, "my_app.opam"))
+	if !strings.Contains(string(content), `"yojson"`) {
+		t.Errorf("expected yojson in opam file:\n%s", content)
+	}
+}
+
+func TestRunAdd_DuneManagedProject_IdempotentAdd(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dune-project"), []byte(addTestDuneProject), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
+	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+		t.Fatalf("first RunAdd: %v", err)
+	}
+	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+		t.Fatalf("second RunAdd: %v", err)
+	}
+
+	content, _ := os.ReadFile(filepath.Join(dir, "dune-project"))
+	count := strings.Count(string(content), "yojson")
+	if count != 1 {
+		t.Errorf("expected yojson exactly once after idempotent add, got %d:\n%s", count, content)
+	}
+}
+
+func TestRunAdd_SyncFuncCalledWithProjectDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dune-project"), []byte(addTestDuneProject), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var syncCalledWith string
+	captureSync := func(d string) error {
+		syncCalledWith = d
+		return nil
+	}
+
+	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
+	if err := cmd.RunAdd(dir, deps, false, captureSync); err != nil {
+		t.Fatalf("RunAdd: %v", err)
+	}
+
+	if syncCalledWith != dir {
+		t.Errorf("sync called with %q, want %q", syncCalledWith, dir)
+	}
+}

--- a/cmd/export_test.go
+++ b/cmd/export_test.go
@@ -8,3 +8,4 @@ var BuildRunArgs = buildRunArgs
 var ParseAddArgs = parseAddArgs
 var RunBuild = runBuild
 var RunRemove = runRemove
+var RunAdd = runAdd


### PR DESCRIPTION
## Summary

- `runAdd` called `sync.Ensure` directly — impossible to unit test without opam installed
- Refactored to accept `syncFn func(string) error`; the cobra command passes `sync.Ensure` as the real implementation
- Exported `RunAdd` via `export_test.go`
- Added 5 unit tests covering: dune-managed add, add with constraint, hand-written opam add, idempotency, sync called with correct dir

## Test plan
- [ ] `go test ./cmd/...` — all pass including new `TestRunAdd_*` tests

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)