### PR TITLE
fix: atomic writes in dune/opam manifest mutation functions

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -1,0 +1,34 @@
+package atomicfile
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Write atomically replaces the file at path with content by writing to a
+// temporary file in the same directory and renaming it. This ensures the file
+// is either the old content or the new content after a crash, never a partial
+// write.
+func Write(path string, content []byte, perm fs.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".atomicwrite.*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(content); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/dune/parse.go
+++ b/internal/dune/parse.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/emilkloeden/oc/internal/atomicfile"
 	"github.com/emilkloeden/oc/internal/project"
 )
 
@@ -146,7 +147,7 @@ func AddDep(dir, pkg, constraint string) error {
 
 	// Insert new entry before the closing ')' of depends
 	newContent := content[:end] + "\n  " + entry + content[end:]
-	return os.WriteFile(path, []byte(newContent), 0644)
+	return atomicfile.Write(path, []byte(newContent), 0644)
 }
 
 // RemoveDep removes a dependency from the (depends ...) stanza in dune-project.
@@ -175,7 +176,7 @@ func RemoveDep(dir, pkg string) error {
 	}
 
 	newContent := content[:start] + filtered + content[end:]
-	return os.WriteFile(path, []byte(newContent), 0644)
+	return atomicfile.Write(path, []byte(newContent), 0644)
 }
 
 // findDepsBounds locates the interior of the (depends ...) block in a dune-project.

--- a/internal/dune/parse_test.go
+++ b/internal/dune/parse_test.go
@@ -245,6 +245,39 @@ func TestHasGenerateOpamFiles_FalseWhenAbsent(t *testing.T) {
 	}
 }
 
+func TestAddDep_NoTempFilesLeft(t *testing.T) {
+	dir := t.TempDir()
+	writeDuneProject(t, dir, sampleDuneProject)
+
+	if err := dune.AddDep(dir, "yojson", "*"); err != nil {
+		t.Fatalf("AddDep: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind in project dir: %s", e.Name())
+		}
+	}
+}
+
+func TestRemoveDep_NoTempFilesLeft(t *testing.T) {
+	dir := t.TempDir()
+	content := "(lang dune 3.0)\n(generate_opam_files true)\n\n(package\n (name my_app)\n (depends\n  dune\n  yojson))\n"
+	writeDuneProject(t, dir, content)
+
+	if err := dune.RemoveDep(dir, "yojson"); err != nil {
+		t.Fatalf("RemoveDep: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind in project dir: %s", e.Name())
+		}
+	}
+}
+
 func writeDuneProjectBytes(t *testing.T, dir string, content []byte) {
 	t.Helper()
 	if err := os.WriteFile(filepath.Join(dir, "dune-project"), content, 0644); err != nil {

--- a/internal/opam/parse.go
+++ b/internal/opam/parse.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/emilkloeden/oc/internal/atomicfile"
 	"github.com/emilkloeden/oc/internal/project"
 )
 
@@ -53,7 +54,7 @@ func AddDepToOpam(path, pkg, constraint string) error {
 	}
 
 	newContent := content[:end] + "  " + entry + "\n" + content[end:]
-	return os.WriteFile(path, []byte(newContent), 0644)
+	return atomicfile.Write(path, []byte(newContent), 0644)
 }
 
 // RemoveDepFromOpam removes a dependency from the depends: block in an opam file.
@@ -78,7 +79,7 @@ func RemoveDepFromOpam(path, pkg string) error {
 		}
 		result = append(result, line)
 	}
-	return os.WriteFile(path, []byte(strings.Join(result, "\n")), 0644)
+	return atomicfile.Write(path, []byte(strings.Join(result, "\n")), 0644)
 }
 
 // findOpamDepsBounds finds the start and end positions of the depends: block.

--- a/internal/opam/parse_test.go
+++ b/internal/opam/parse_test.go
@@ -186,6 +186,38 @@ func TestReadOCamlVersion_MissingOpamFile(t *testing.T) {
 	}
 }
 
+func TestAddDepToOpam_NoTempFilesLeft(t *testing.T) {
+	dir := t.TempDir()
+	path := writeOpam(t, dir, "my_app", sampleOpam)
+
+	if err := opam.AddDepToOpam(path, "yojson", "*"); err != nil {
+		t.Fatalf("AddDepToOpam: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestRemoveDepFromOpam_NoTempFilesLeft(t *testing.T) {
+	dir := t.TempDir()
+	path := writeOpam(t, dir, "my_app", sampleOpamWithDep)
+
+	if err := opam.RemoveDepFromOpam(path, "yojson"); err != nil {
+		t.Fatalf("RemoveDepFromOpam: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind: %s", e.Name())
+		}
+	}
+}
+
 func TestAddDepToOpam_InsertsInsideDependsBlockNotAtFileStart(t *testing.T) {
 	// Ensures insertion uses the correct block bounds (end position),
 	// not position 0 (which would prepend before the file header).


### PR DESCRIPTION
## Summary

- `AddDep`, `RemoveDep`, `AddDepToOpam`, `RemoveDepFromOpam` all used `os.WriteFile` directly — a crash between the write and return could leave the manifest partially written
- Created `internal/atomicfile.Write`: write to a same-directory temp file, chmod, then `os.Rename` to the final path (same pattern used by `project.SaveState`)
- All four functions now use `atomicfile.Write`

## Test plan
- [ ] `go test ./...` — all pass including new "no temp files left" tests for all four functions

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)