### PR TITLE
fix: depth-tracking scanner for findOpamDepsBounds

### DIFF
--- a/internal/opam/parse.go
+++ b/internal/opam/parse.go
@@ -83,24 +83,45 @@ func RemoveDepFromOpam(path, pkg string) error {
 }
 
 // findOpamDepsBounds finds the start and end positions of the depends: block.
-// 'start' is after "depends: [", 'end' is the position of the closing ']'.
+// 'start' is after the opening '[', 'end' is the position of the matching closing ']'.
+// Uses depth-tracking to correctly handle nested [...] inside the block.
 func findOpamDepsBounds(content string) (start, end int, err error) {
+	var opener string
 	idx := strings.Index(content, "depends: [")
-	if idx < 0 {
+	if idx >= 0 {
+		opener = "depends: ["
+	} else {
 		idx = strings.Index(content, "depends:[")
 		if idx < 0 {
 			return 0, 0, fmt.Errorf("no depends: field found in opam file")
 		}
-		start = idx + len("depends:[")
-	} else {
-		start = idx + len("depends: [")
+		opener = "depends:["
 	}
+	start = idx + len(opener)
 
-	end = strings.Index(content[start:], "]")
-	if end < 0 {
-		return 0, 0, fmt.Errorf("unterminated depends: block in opam file")
+	depth := 1
+	i := start
+	inString := false
+	for i < len(content) {
+		c := content[i]
+		switch {
+		case inString && c == '"':
+			inString = false
+		case inString && c == '\\':
+			i++
+		case !inString && c == '"':
+			inString = true
+		case !inString && c == '[':
+			depth++
+		case !inString && c == ']':
+			depth--
+			if depth == 0 {
+				return start, i, nil
+			}
+		}
+		i++
 	}
-	return start, start + end, nil
+	return 0, 0, fmt.Errorf("unterminated depends: block in opam file")
 }
 
 // opamHasDep reports whether pkg appears in the depends: block of an opam file.

--- a/internal/opam/parse_test.go
+++ b/internal/opam/parse_test.go
@@ -186,6 +186,53 @@ func TestReadOCamlVersion_MissingOpamFile(t *testing.T) {
 	}
 }
 
+func TestAddDepToOpam_NestedBracketsInDependsBlock(t *testing.T) {
+	// opam's depends: block can contain nested [...] (alternatives/conjunctions).
+	// The naive strings.Index(content[start:], "]") finds the first "]" which is
+	// inside the nested block, causing the outer block bounds to be wrong.
+	dir := t.TempDir()
+	content := `opam-version: "2.0"
+name: "my_app"
+depends: [
+  [ "pkg1" | "pkg2" ]
+  "dune" {>= "3.0"}
+]
+`
+	path := writeOpam(t, dir, "my_app", content)
+	if err := opam.AddDepToOpam(path, "yojson", "*"); err != nil {
+		t.Fatalf("AddDepToOpam: %v", err)
+	}
+
+	result, _ := os.ReadFile(path)
+	if !strings.Contains(string(result), `"yojson"`) {
+		t.Errorf("expected yojson to be added:\n%s", result)
+	}
+	// Verify the nested alternatives block was not corrupted.
+	if !strings.Contains(string(result), `[ "pkg1" | "pkg2" ]`) {
+		t.Errorf("nested alternatives block corrupted:\n%s", result)
+	}
+}
+
+func TestReadOCamlVersion_NestedBracketsBeforeOcaml(t *testing.T) {
+	// Nested [ ] before the ocaml entry — naive search finds the inner ] first.
+	dir := t.TempDir()
+	content := `opam-version: "2.0"
+depends: [
+  [ "pkg1" | "pkg2" ]
+  "ocaml" {>= "5.2.0"}
+  "dune" {>= "3.0"}
+]
+`
+	writeOpam(t, dir, "my_app", content)
+	v, err := opam.ReadOCamlVersion(dir)
+	if err != nil {
+		t.Fatalf("ReadOCamlVersion: %v", err)
+	}
+	if v != "5.2.0" {
+		t.Errorf("got %q, want %q", v, "5.2.0")
+	}
+}
+
 func TestAddDepToOpam_NoTempFilesLeft(t *testing.T) {
 	dir := t.TempDir()
 	path := writeOpam(t, dir, "my_app", sampleOpam)


### PR DESCRIPTION
## Summary

- `findOpamDepsBounds` used `strings.Index(content[start:], "]")` which matched the first `]` in the file, including ones inside nested `[ ... ]` blocks (opam alternatives/conjunctions)
- Replaced with a string-aware depth-tracking scanner that counts matching `[`/`]` pairs, identical in structure to the `findStanzaBounds` used for dune S-expressions

## Test plan
- [ ] `go test ./internal/opam/...` — all pass including `TestAddDepToOpam_NestedBracketsInDependsBlock` and `TestReadOCamlVersion_NestedBracketsBeforeOcaml`

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)