### PR TITLE
fix: align isProjectDir with project.Detect for dune-project

### DIFF
--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -10,9 +10,10 @@ import (
 	"github.com/emilkloeden/oc/internal/project"
 )
 
-func TestProjectRoot_FindsDuneProject(t *testing.T) {
+func TestProjectRoot_FindsDuneManagedProject(t *testing.T) {
 	dir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(dir, "dune-project"), []byte("(lang dune 3.0)\n"), 0644); err != nil {
+	content := "(lang dune 3.0)\n(generate_opam_files true)\n\n(package\n (name my_app)\n (depends dune))\n"
+	if err := os.WriteFile(filepath.Join(dir, "dune-project"), []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -27,6 +28,45 @@ func TestProjectRoot_FindsDuneProject(t *testing.T) {
 	}
 	if root != dir {
 		t.Errorf("got %q want %q", root, dir)
+	}
+}
+
+func TestProjectRoot_FindsHandWrittenOpamProject(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "my_app.opam"), []byte("opam-version: \"2.0\"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	subdir := filepath.Join(dir, "a", "b")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	root, err := cmd.FindProjectRoot(subdir)
+	if err != nil {
+		t.Fatalf("cmd.FindProjectRoot: %v", err)
+	}
+	if root != dir {
+		t.Errorf("got %q want %q", root, dir)
+	}
+}
+
+func TestProjectRoot_DoesNotFindBareDuneProjectWithoutOpam(t *testing.T) {
+	// A bare dune-project (no generate_opam_files, no .opam file) is not
+	// an oc project and should not be accepted as a project root.
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "dune-project"), []byte("(lang dune 3.0)\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	subdir := filepath.Join(dir, "a", "b")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := cmd.FindProjectRoot(subdir)
+	if err == nil {
+		t.Error("expected error for bare dune-project without generate_opam_files or .opam, got nil")
 	}
 }
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -30,23 +30,30 @@ func findProjectRoot(start string) (string, error) {
 	return "", fmt.Errorf("no OCaml project found (no dune-project or .opam file in %s or any parent directory)", start)
 }
 
-// isProjectDir reports whether dir looks like an OCaml project root.
-// Recognised markers: dune-project, *.opam file, or .oc/ directory (oc state).
+// isProjectDir reports whether dir looks like an OCaml project root that oc can manage.
+// Recognised markers (in priority order):
+//  1. dune-project with (generate_opam_files — dune-managed project
+//  2. *.opam file — hand-written opam project
+//  3. .oc/ directory — machine-local oc state (project already initialised)
+//
+// A bare dune-project without generate_opam_files and without a .opam file
+// is not accepted, keeping this consistent with project.Detect.
 func isProjectDir(dir string) bool {
-	if _, err := os.Stat(filepath.Join(dir, "dune-project")); err == nil {
-		return true
+	if data, err := os.ReadFile(filepath.Join(dir, "dune-project")); err == nil {
+		if strings.Contains(string(data), "(generate_opam_files") {
+			return true
+		}
+	}
+	entries, err := os.ReadDir(dir)
+	if err == nil {
+		for _, e := range entries {
+			if !e.IsDir() && strings.HasSuffix(e.Name(), ".opam") {
+				return true
+			}
+		}
 	}
 	if _, err := os.Stat(filepath.Join(dir, ".oc")); err == nil {
 		return true
-	}
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return false
-	}
-	for _, e := range entries {
-		if !e.IsDir() && strings.HasSuffix(e.Name(), ".opam") {
-			return true
-		}
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

- `isProjectDir` accepted any `dune-project` file as an oc project root, but `project.Detect` only classifies it as `TypeDuneManaged` when `(generate_opam_files` is present
- A directory with a bare `dune-project` + no `.opam` file could be found by the root-walker but then fail at `Detect` with a confusing "no OCaml project found" error
- Fixed `isProjectDir` to mirror `Detect`: `dune-project` only qualifies if it contains `(generate_opam_files`; hand-written `.opam` and `.oc/` remain as valid markers

## Test plan
- [ ] `go test ./cmd/...` — all pass including `TestProjectRoot_DoesNotFindBareDuneProjectWithoutOpam`, `TestProjectRoot_FindsDuneManagedProject`, `TestProjectRoot_FindsHandWrittenOpamProject`

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)