### PR TITLE
refactor: remove dead countParenDepth function

### DIFF
--- a/internal/dune/parse.go
+++ b/internal/dune/parse.go
@@ -378,27 +378,6 @@ func removeDuneDepEntry(interior, pkg string) (string, bool) {
 	return out.String(), true
 }
 
-// countParenDepth returns the net paren depth of a string (opens - closes).
-func countParenDepth(s string) int {
-	depth := 0
-	inStr := false
-	for i := 0; i < len(s); i++ {
-		c := s[i]
-		switch {
-		case inStr && c == '"':
-			inStr = false
-		case inStr && c == '\\':
-			i++
-		case !inStr && c == '"':
-			inStr = true
-		case !inStr && c == '(':
-			depth++
-		case !inStr && c == ')':
-			depth--
-		}
-	}
-	return depth
-}
 
 // formatDuneDepEntry formats a dep entry for insertion into a dune-project depends block.
 func formatDuneDepEntry(pkg, constraint string) string {


### PR DESCRIPTION
## Summary
- Removes `countParenDepth` from `internal/dune/parse.go` — it had no callers after the `removeDuneDepEntry` rewrite in #36
- `go build ./...` and `go test ./...` confirm nothing references it

Closes #68

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)