### PR TITLE
fix: remove --dev flag from oc add (silently no-ops)

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -11,8 +11,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var addDev bool
-
 var addCmd = &cobra.Command{
 	Use:   "add <package> [constraint] [<package> [constraint]]...",
 	Short: "Add one or more dependencies to the project",
@@ -28,7 +26,7 @@ var addCmd = &cobra.Command{
 			return err
 		}
 
-		if err := runAdd(dir, deps, addDev, sync.Ensure); err != nil {
+		if err := runAdd(dir, deps, sync.Ensure); err != nil {
 			return err
 		}
 
@@ -40,7 +38,7 @@ var addCmd = &cobra.Command{
 }
 
 // runAdd adds deps to the project manifest and syncs.
-func runAdd(dir string, deps []project.Dep, dev bool, syncFn func(string) error) error {
+func runAdd(dir string, deps []project.Dep, syncFn func(string) error) error {
 	pt, err := project.Detect(dir)
 	if err != nil {
 		return err
@@ -102,6 +100,5 @@ func parseAddArgs(args []string) ([]project.Dep, error) {
 }
 
 func init() {
-	addCmd.Flags().BoolVar(&addDev, "dev", false, "add as a dev dependency")
 	rootCmd.AddCommand(addCmd)
 }

--- a/cmd/add_unit_test.go
+++ b/cmd/add_unit_test.go
@@ -38,7 +38,7 @@ func TestRunAdd_DuneManagedProject_AddsToduneProject(t *testing.T) {
 	}
 
 	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
-	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+	if err := cmd.RunAdd(dir, deps, noopSync); err != nil {
 		t.Fatalf("RunAdd: %v", err)
 	}
 
@@ -55,7 +55,7 @@ func TestRunAdd_DuneManagedProject_AddsWithConstraint(t *testing.T) {
 	}
 
 	deps := []project.Dep{{Name: "cohttp", Constraint: ">=5.0.0"}}
-	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+	if err := cmd.RunAdd(dir, deps, noopSync); err != nil {
 		t.Fatalf("RunAdd: %v", err)
 	}
 
@@ -72,7 +72,7 @@ func TestRunAdd_HandWrittenOpam_AddsToOpamFile(t *testing.T) {
 	}
 
 	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
-	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+	if err := cmd.RunAdd(dir, deps, noopSync); err != nil {
 		t.Fatalf("RunAdd: %v", err)
 	}
 
@@ -89,10 +89,10 @@ func TestRunAdd_DuneManagedProject_IdempotentAdd(t *testing.T) {
 	}
 
 	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
-	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+	if err := cmd.RunAdd(dir, deps, noopSync); err != nil {
 		t.Fatalf("first RunAdd: %v", err)
 	}
-	if err := cmd.RunAdd(dir, deps, false, noopSync); err != nil {
+	if err := cmd.RunAdd(dir, deps, noopSync); err != nil {
 		t.Fatalf("second RunAdd: %v", err)
 	}
 
@@ -116,7 +116,7 @@ func TestRunAdd_SyncFuncCalledWithProjectDir(t *testing.T) {
 	}
 
 	deps := []project.Dep{{Name: "yojson", Constraint: "*"}}
-	if err := cmd.RunAdd(dir, deps, false, captureSync); err != nil {
+	if err := cmd.RunAdd(dir, deps, captureSync); err != nil {
 		t.Fatalf("RunAdd: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- Removes `--dev` flag from `oc add` — it was registered and accepted but never read inside `runAdd`
- Removes `addDev` package-level variable, `dev bool` parameter from `runAdd`, and the flag registration
- Updates `add_unit_test.go` to match the new signature

Closes #67

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)