### PR TITLE
fix: clean up temp file if os.Rename fails in atomicfile.Write

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -30,5 +30,9 @@ func Write(path string, content []byte, perm fs.FileMode) error {
 		_ = os.Remove(tmpPath)
 		return err
 	}
-	return os.Rename(tmpPath, path)
+	if err := os.Rename(tmpPath, path); err != nil {
+		_ = os.Remove(tmpPath)
+		return err
+	}
+	return nil
 }

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -1,0 +1,53 @@
+package atomicfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/emilkloeden/oc/internal/atomicfile"
+)
+
+// TestWrite_CleansTempFileOnRenameFailure verifies that no .tmp file is left
+// behind when os.Rename fails. We force the failure by making the destination
+// path a directory (Rename to an existing dir returns EISDIR on POSIX).
+func TestWrite_CleansTempFileOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "target")
+	if err := os.Mkdir(dest, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := atomicfile.Write(dest, []byte("hello"), 0644)
+	if err == nil {
+		t.Fatal("expected error when rename target is a directory, got nil")
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind after rename failure: %s", e.Name())
+		}
+	}
+}
+
+func TestWrite_SuccessNoTempFiles(t *testing.T) {
+	dir := t.TempDir()
+	dest := filepath.Join(dir, "out.txt")
+
+	if err := atomicfile.Write(dest, []byte("content"), 0644); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind on success: %s", e.Name())
+		}
+	}
+	data, _ := os.ReadFile(dest)
+	if string(data) != "content" {
+		t.Errorf("got %q, want %q", data, "content")
+	}
+}


### PR DESCRIPTION
## Summary
- `atomicfile.Write` now removes the temp file if `os.Rename` fails, preventing a disk leak
- Adds `atomicfile_test.go` with a failure-path test (forces EISDIR by making the destination a directory) and a success-path test

Closes #66

## Test plan
- [x] `TestWrite_CleansTempFileOnRenameFailure` — was failing (temp file leaked), now passes
- [x] `TestWrite_SuccessNoTempFiles` — new test for clean success path
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)