### PR TITLE
fix: return error from CachePathForVersion when UserHomeDir fails

### DIFF
--- a/internal/switch/switch.go
+++ b/internal/switch/switch.go
@@ -9,12 +9,15 @@ import (
 
 // CachePathForVersion returns the content-addressed switch path for the given OCaml version.
 // All projects using the same OCaml version share the same switch (dependencies accumulate via opam).
-func CachePathForVersion(ocamlVersion string) string {
-	home, _ := os.UserHomeDir()
+func CachePathForVersion(ocamlVersion string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home directory: %w", err)
+	}
 	h := sha256.New()
 	fmt.Fprintf(h, "ocaml=%s\n", ocamlVersion)
 	hash := fmt.Sprintf("%x", h.Sum(nil))[:16]
-	return filepath.Join(home, ".cache", "oc", "switches", hash)
+	return filepath.Join(home, ".cache", "oc", "switches", hash), nil
 }
 
 // EnsureSymlink creates or updates the .ocaml symlink in projectDir to point at target.

--- a/internal/switch/switch_test.go
+++ b/internal/switch/switch_test.go
@@ -10,23 +10,38 @@ import (
 )
 
 func TestCachePathForVersion_Deterministic(t *testing.T) {
-	p1 := sw.CachePathForVersion("5.2.0")
-	p2 := sw.CachePathForVersion("5.2.0")
+	p1, err := sw.CachePathForVersion("5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForVersion: %v", err)
+	}
+	p2, err := sw.CachePathForVersion("5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForVersion: %v", err)
+	}
 	if p1 != p2 {
 		t.Errorf("CachePathForVersion not deterministic: %q vs %q", p1, p2)
 	}
 }
 
 func TestCachePathForVersion_DiffersForDifferentVersions(t *testing.T) {
-	p1 := sw.CachePathForVersion("5.2.0")
-	p2 := sw.CachePathForVersion("5.3.0")
+	p1, err := sw.CachePathForVersion("5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForVersion: %v", err)
+	}
+	p2, err := sw.CachePathForVersion("5.3.0")
+	if err != nil {
+		t.Fatalf("CachePathForVersion: %v", err)
+	}
 	if p1 == p2 {
 		t.Error("different OCaml versions should produce different cache paths")
 	}
 }
 
 func TestCachePathForVersion_ContainsExpectedSegments(t *testing.T) {
-	path := sw.CachePathForVersion("5.2.0")
+	path, err := sw.CachePathForVersion("5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForVersion: %v", err)
+	}
 	if !strings.Contains(path, filepath.Join(".cache", "oc", "switches")) {
 		t.Errorf("unexpected path structure: %q", path)
 	}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -74,7 +74,11 @@ func EnsureWith(dir string, ocamlVersion string, runner OpamRunner) error {
 
 	switchPath := state.SwitchPath
 	if switchPath == "" || !runner.SwitchExists(switchPath) {
-		switchPath = swmgr.CachePathForVersion(ocamlVersion)
+		var err error
+		switchPath, err = swmgr.CachePathForVersion(ocamlVersion)
+		if err != nil {
+			return fmt.Errorf("compute switch path: %w", err)
+		}
 	}
 
 	if !runner.SwitchExists(switchPath) {


### PR DESCRIPTION
## Summary
- `CachePathForVersion` now returns `(string, error)` instead of silently using an empty home directory
- `sync.EnsureWith` propagates the error with context
- All tests updated to handle the new signature

Closes #65

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all switch and sync tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)