### PR TITLE
fix: clean up temp file if rename fails in SaveState

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,12 +1,14 @@
 package project
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/BurntSushi/toml"
+	"github.com/emilkloeden/oc/internal/atomicfile"
 )
 
 const stateDir = ".oc"
@@ -41,22 +43,11 @@ func SaveState(dir string, s State) error {
 	if err := os.MkdirAll(ocDir, 0755); err != nil {
 		return err
 	}
-	path := filepath.Join(ocDir, stateFile)
-	tmp, err := os.CreateTemp(ocDir, ".state.*.tmp")
-	if err != nil {
+	var buf bytes.Buffer
+	if err := toml.NewEncoder(&buf).Encode(s); err != nil {
 		return err
 	}
-	tmpPath := tmp.Name()
-	if err := toml.NewEncoder(tmp).Encode(s); err != nil {
-		_ = tmp.Close()
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	if err := tmp.Close(); err != nil {
-		_ = os.Remove(tmpPath)
-		return err
-	}
-	return os.Rename(tmpPath, path)
+	return atomicfile.Write(filepath.Join(ocDir, stateFile), buf.Bytes(), 0644)
 }
 
 // Dep represents a package name and its version constraint as parsed from CLI arguments.

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -93,6 +93,29 @@ func TestSaveState_ConcurrentWritesProduceValidFile(t *testing.T) {
 	}
 }
 
+func TestSaveState_CleansTempFileOnRenameFailure(t *testing.T) {
+	// Force os.Rename to fail by making the destination path a directory.
+	// CreateTemp still succeeds (it uses .oc/ as its dir), but Rename to
+	// state.toml/ (a directory) fails with EISDIR.
+	dir := t.TempDir()
+	ocDir := filepath.Join(dir, ".oc")
+	if err := os.MkdirAll(filepath.Join(ocDir, "state.toml"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := project.SaveState(dir, project.State{SwitchPath: "/tmp/sw"})
+	if err == nil {
+		t.Fatal("expected error when rename target is a directory, got nil")
+	}
+
+	entries, _ := os.ReadDir(ocDir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Errorf("temp file left behind after rename failure: %s", e.Name())
+		}
+	}
+}
+
 func TestParseConstraintParts_GEOperator(t *testing.T) {
 	op, ver := project.ParseConstraintParts(">=5.2.0")
 	if op != ">=" || ver != "5.2.0" {


### PR DESCRIPTION
## Summary
- `SaveState` had the same temp-file leak fixed in #66 for `atomicfile.Write`: `os.Rename` failure left a `.tmp` file in `.oc/`
- Refactors `SaveState` to encode to a `bytes.Buffer` then delegate to `atomicfile.Write`, which already handles cleanup on all error paths
- Adds `TestSaveState_CleansTempFileOnRenameFailure` that forces the failure by making the destination path a directory (EISDIR)

## Test plan
- [x] `TestSaveState_CleansTempFileOnRenameFailure` was failing (temp file leaked), now passes
- [x] All existing project tests still pass
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)