### PR TITLE
feat: per-project switch isolation with incremental cloning

### DIFF
--- a/internal/switch/switch.go
+++ b/internal/switch/switch.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CachePathForVersion returns the content-addressed switch path for the given OCaml version.
-// All projects using the same OCaml version share the same switch (dependencies accumulate via opam).
+// Kept for backward compatibility with state.toml entries written by older versions.
 func CachePathForVersion(ocamlVersion string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -18,6 +18,39 @@ func CachePathForVersion(ocamlVersion string) (string, error) {
 	fmt.Fprintf(h, "ocaml=%s\n", ocamlVersion)
 	hash := fmt.Sprintf("%x", h.Sum(nil))[:16]
 	return filepath.Join(home, ".cache", "oc", "switches", hash), nil
+}
+
+// CachePathForProject returns a per-project switch path, unique to the combination
+// of absolute project directory and OCaml version. This gives each project its own
+// isolated switch while still being deterministic and content-addressed.
+func CachePathForProject(projectDir, ocamlVersion string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("determine home directory: %w", err)
+	}
+	h := sha256.New()
+	fmt.Fprintf(h, "ocaml=%s\nproject=%s\n", ocamlVersion, projectDir)
+	hash := fmt.Sprintf("%x", h.Sum(nil))[:16]
+	return filepath.Join(home, ".cache", "oc", "switches", hash), nil
+}
+
+// ListCachedSwitches returns all switch directory paths found under base.
+// In production, base is ~/.cache/oc/switches; tests pass a temp dir.
+func ListCachedSwitches(base string) ([]string, error) {
+	entries, err := os.ReadDir(base)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read switches dir: %w", err)
+	}
+	var paths []string
+	for _, e := range entries {
+		if e.IsDir() {
+			paths = append(paths, filepath.Join(base, e.Name()))
+		}
+	}
+	return paths, nil
 }
 
 // EnsureSymlink creates or updates the .ocaml symlink in projectDir to point at target.

--- a/internal/switch/switch_test.go
+++ b/internal/switch/switch_test.go
@@ -111,6 +111,90 @@ func TestEnsureSymlink_RegularFileReturnsError(t *testing.T) {
 	}
 }
 
+func TestCachePathForProject_Deterministic(t *testing.T) {
+	p1, err := sw.CachePathForProject("/home/user/myproject", "5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForProject: %v", err)
+	}
+	p2, err := sw.CachePathForProject("/home/user/myproject", "5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForProject: %v", err)
+	}
+	if p1 != p2 {
+		t.Errorf("CachePathForProject not deterministic: %q vs %q", p1, p2)
+	}
+}
+
+func TestCachePathForProject_DiffersForDifferentVersions(t *testing.T) {
+	p1, err := sw.CachePathForProject("/home/user/myproject", "5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForProject: %v", err)
+	}
+	p2, err := sw.CachePathForProject("/home/user/myproject", "5.3.0")
+	if err != nil {
+		t.Fatalf("CachePathForProject: %v", err)
+	}
+	if p1 == p2 {
+		t.Error("different OCaml versions should produce different cache paths")
+	}
+}
+
+func TestCachePathForProject_DiffersForDifferentProjectDirs(t *testing.T) {
+	p1, err := sw.CachePathForProject("/home/user/projectA", "5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForProject: %v", err)
+	}
+	p2, err := sw.CachePathForProject("/home/user/projectB", "5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForProject: %v", err)
+	}
+	if p1 == p2 {
+		t.Error("different project dirs should produce different cache paths")
+	}
+}
+
+func TestCachePathForProject_ContainsExpectedSegments(t *testing.T) {
+	path, err := sw.CachePathForProject("/home/user/myproject", "5.2.0")
+	if err != nil {
+		t.Fatalf("CachePathForProject: %v", err)
+	}
+	if !strings.Contains(path, filepath.Join(".cache", "oc", "switches")) {
+		t.Errorf("unexpected path structure: %q", path)
+	}
+	base := filepath.Base(path)
+	if len(base) != 16 {
+		t.Errorf("expected 16-char hash in path base, got %q (len %d)", base, len(base))
+	}
+}
+
+func TestListCachedSwitches_EmptyWhenNone(t *testing.T) {
+	switches, err := sw.ListCachedSwitches(t.TempDir())
+	if err != nil {
+		t.Fatalf("ListCachedSwitches: %v", err)
+	}
+	if len(switches) != 0 {
+		t.Errorf("expected empty list, got %v", switches)
+	}
+}
+
+func TestListCachedSwitches_ReturnsDirectories(t *testing.T) {
+	base := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(base, "abc123"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(base, "def456"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	switches, err := sw.ListCachedSwitches(base)
+	if err != nil {
+		t.Fatalf("ListCachedSwitches: %v", err)
+	}
+	if len(switches) != 2 {
+		t.Errorf("expected 2 switches, got %d: %v", len(switches), switches)
+	}
+}
+
 func TestEnsureSymlink_DirectoryReturnsError(t *testing.T) {
 	projectDir := t.TempDir()
 	link := filepath.Join(projectDir, ".ocaml")

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -3,6 +3,8 @@ package sync
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/emilkloeden/oc/internal/defaults"
 	"github.com/emilkloeden/oc/internal/exec"
@@ -16,6 +18,9 @@ type OpamRunner interface {
 	CreateSwitch(path, ocamlVersion string) error
 	InstallDeps(dir, switchPath string) error
 	LockDeps(dir string) error
+	CloneSwitch(source, dest string) error
+	GetSwitchOCamlVersion(switchPath string) (string, error)
+	ListCachedSwitches() ([]string, error)
 }
 
 type realRunner struct{}
@@ -44,6 +49,58 @@ func (r *realRunner) InstallDeps(dir, switchPath string) error {
 
 func (r *realRunner) LockDeps(dir string) error {
 	return exec.Run("opam", []string{"lock", "."}, exec.Options{Dir: dir})
+}
+
+func (r *realRunner) CloneSwitch(source, dest string) error {
+	fmt.Printf("Cloning existing switch as base (this may take a moment)...\n")
+	if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+		return fmt.Errorf("create switches dir: %w", err)
+	}
+	return exec.Run("opam", []string{
+		"switch", "copy", source, dest,
+	}, exec.Options{})
+}
+
+func (r *realRunner) GetSwitchOCamlVersion(switchPath string) (string, error) {
+	out, err := exec.Output("opam", []string{
+		"list", "ocaml", "--installed", "--short", "--columns=version",
+		"--switch", switchPath,
+	}, exec.Options{})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func (r *realRunner) ListCachedSwitches() ([]string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("determine home directory: %w", err)
+	}
+	return swmgr.ListCachedSwitches(filepath.Join(home, ".cache", "oc", "switches"))
+}
+
+// findBestBase returns the path of the best existing switch to clone from for
+// targetVersion. It picks the first compatible switch (same OCaml version) that
+// is not the target path itself. Returns "" when no suitable base exists.
+func findBestBase(targetPath, ocamlVersion string, runner OpamRunner) string {
+	candidates, err := runner.ListCachedSwitches()
+	if err != nil || len(candidates) == 0 {
+		return ""
+	}
+	for _, p := range candidates {
+		if p == targetPath || !runner.SwitchExists(p) {
+			continue
+		}
+		v, err := runner.GetSwitchOCamlVersion(p)
+		if err != nil {
+			continue
+		}
+		if v == ocamlVersion {
+			return p
+		}
+	}
+	return ""
 }
 
 // Ensure is the public entry point using the real opam runner.
@@ -75,15 +132,26 @@ func EnsureWith(dir string, ocamlVersion string, runner OpamRunner) error {
 	switchPath := state.SwitchPath
 	if switchPath == "" || !runner.SwitchExists(switchPath) {
 		var err error
-		switchPath, err = swmgr.CachePathForVersion(ocamlVersion)
+		switchPath, err = swmgr.CachePathForProject(dir, ocamlVersion)
 		if err != nil {
 			return fmt.Errorf("compute switch path: %w", err)
 		}
 	}
 
 	if !runner.SwitchExists(switchPath) {
-		if err := runner.CreateSwitch(switchPath, ocamlVersion); err != nil {
-			return fmt.Errorf("create switch: %w", err)
+		base := findBestBase(switchPath, ocamlVersion, runner)
+		if base != "" {
+			if err := runner.CloneSwitch(base, switchPath); err != nil {
+				// Clone failed — fall back to a clean create.
+				fmt.Fprintf(os.Stderr, "warning: switch clone failed, creating from scratch: %v\n", err)
+				if err2 := runner.CreateSwitch(switchPath, ocamlVersion); err2 != nil {
+					return fmt.Errorf("create switch: %w", err2)
+				}
+			}
+		} else {
+			if err := runner.CreateSwitch(switchPath, ocamlVersion); err != nil {
+				return fmt.Errorf("create switch: %w", err)
+			}
 		}
 	}
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -11,12 +11,16 @@ import (
 )
 
 type mockRunner struct {
-	switches      map[string]bool
-	createCalled  []string
-	installCalled []string
-	lockCalled    []string
-	createErr     error
-	installErr    error
+	switches       map[string]bool
+	switchVersions map[string]string // path → ocaml version
+	createCalled   []string
+	installCalled  []string
+	lockCalled     []string
+	cloneCalled    [][2]string // [source, dest] pairs
+	cachedSwitches []string   // returned by ListCachedSwitches
+	createErr      error
+	installErr     error
+	cloneErr       error
 }
 
 func (m *mockRunner) SwitchExists(path string) bool {
@@ -25,8 +29,15 @@ func (m *mockRunner) SwitchExists(path string) bool {
 
 func (m *mockRunner) CreateSwitch(path, ocamlVersion string) error {
 	m.createCalled = append(m.createCalled, path)
+	if m.createErr != nil {
+		return m.createErr
+	}
 	m.switches[path] = true
-	return m.createErr
+	if m.switchVersions == nil {
+		m.switchVersions = map[string]string{}
+	}
+	m.switchVersions[path] = ocamlVersion
+	return nil
 }
 
 func (m *mockRunner) InstallDeps(dir, switchPath string) error {
@@ -37,6 +48,30 @@ func (m *mockRunner) InstallDeps(dir, switchPath string) error {
 func (m *mockRunner) LockDeps(dir string) error {
 	m.lockCalled = append(m.lockCalled, dir)
 	return nil
+}
+
+func (m *mockRunner) CloneSwitch(source, dest string) error {
+	m.cloneCalled = append(m.cloneCalled, [2]string{source, dest})
+	if m.cloneErr != nil {
+		return m.cloneErr
+	}
+	m.switches[dest] = true
+	if m.switchVersions == nil {
+		m.switchVersions = map[string]string{}
+	}
+	m.switchVersions[dest] = m.switchVersions[source]
+	return nil
+}
+
+func (m *mockRunner) GetSwitchOCamlVersion(switchPath string) (string, error) {
+	if v, ok := m.switchVersions[switchPath]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("switch not found: %s", switchPath)
+}
+
+func (m *mockRunner) ListCachedSwitches() ([]string, error) {
+	return m.cachedSwitches, nil
 }
 
 func TestEnsureWith_CreatesSwitch_WhenMissing(t *testing.T) {
@@ -56,11 +91,9 @@ func TestEnsureWith_SkipsCreate_WhenSwitchExists(t *testing.T) {
 	dir := t.TempDir()
 	runner := &mockRunner{switches: map[string]bool{}}
 
-	// first call creates
 	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
 		t.Fatal(err)
 	}
-	// second call should reuse
 	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
 		t.Fatalf("second EnsureWith: %v", err)
 	}
@@ -138,14 +171,12 @@ func TestEnsureWith_ReusesSwitchPathAcrossCalls(t *testing.T) {
 	dir := t.TempDir()
 	runner := &mockRunner{switches: map[string]bool{}}
 
-	// First call: switch created, state written with switch path
 	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
 		t.Fatal(err)
 	}
 	s1, _ := project.LoadState(dir)
 	path1 := s1.SwitchPath
 
-	// Second call: should reuse stored path, not recompute
 	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
 		t.Fatal(err)
 	}
@@ -177,7 +208,6 @@ func TestEnsureWith_NewSwitchOnOCamlVersionChange(t *testing.T) {
 	dir := t.TempDir()
 	runner := &mockRunner{switches: map[string]bool{}}
 
-	// First call with 5.2.0
 	if err := sync.EnsureWith(dir, "5.2.0", runner); err != nil {
 		t.Fatal(err)
 	}
@@ -186,7 +216,8 @@ func TestEnsureWith_NewSwitchOnOCamlVersionChange(t *testing.T) {
 	}
 	path1 := runner.createCalled[0]
 
-	// Second call with a different OCaml version — stored path must be discarded
+	runner.cachedSwitches = []string{path1}
+
 	if err := sync.EnsureWith(dir, "5.3.0", runner); err != nil {
 		t.Fatal(err)
 	}
@@ -197,5 +228,108 @@ func TestEnsureWith_NewSwitchOnOCamlVersionChange(t *testing.T) {
 
 	if path1 == path2 {
 		t.Error("expected different switch paths for different OCaml versions")
+	}
+}
+
+func TestEnsureWith_ClonesSwitch_WhenCompatibleBaseExists(t *testing.T) {
+	dirA := t.TempDir()
+	runnerA := &mockRunner{switches: map[string]bool{}}
+	if err := sync.EnsureWith(dirA, "5.2.0", runnerA); err != nil {
+		t.Fatal(err)
+	}
+	existingSwitch := runnerA.createCalled[0]
+
+	dirB := t.TempDir()
+	runner := &mockRunner{
+		switches:       map[string]bool{existingSwitch: true},
+		switchVersions: map[string]string{existingSwitch: "5.2.0"},
+		cachedSwitches: []string{existingSwitch},
+	}
+
+	if err := sync.EnsureWith(dirB, "5.2.0", runner); err != nil {
+		t.Fatalf("EnsureWith: %v", err)
+	}
+
+	if len(runner.cloneCalled) != 1 {
+		t.Errorf("expected CloneSwitch called once, got %d", len(runner.cloneCalled))
+	}
+	if len(runner.createCalled) != 0 {
+		t.Errorf("expected CreateSwitch not called when base exists, got %d calls", len(runner.createCalled))
+	}
+	if runner.cloneCalled[0][0] != existingSwitch {
+		t.Errorf("clone source: got %q, want %q", runner.cloneCalled[0][0], existingSwitch)
+	}
+}
+
+func TestEnsureWith_FallsBackToCreate_WhenCloneFails(t *testing.T) {
+	dirA := t.TempDir()
+	runnerA := &mockRunner{switches: map[string]bool{}}
+	if err := sync.EnsureWith(dirA, "5.2.0", runnerA); err != nil {
+		t.Fatal(err)
+	}
+	existingSwitch := runnerA.createCalled[0]
+
+	dirB := t.TempDir()
+	runner := &mockRunner{
+		switches:       map[string]bool{existingSwitch: true},
+		switchVersions: map[string]string{existingSwitch: "5.2.0"},
+		cachedSwitches: []string{existingSwitch},
+		cloneErr:       fmt.Errorf("opam switch copy failed"),
+	}
+
+	if err := sync.EnsureWith(dirB, "5.2.0", runner); err != nil {
+		t.Fatalf("EnsureWith should succeed via fallback: %v", err)
+	}
+
+	if len(runner.createCalled) != 1 {
+		t.Errorf("expected CreateSwitch called once as fallback, got %d", len(runner.createCalled))
+	}
+}
+
+func TestEnsureWith_SkipsClone_WhenNoCompatibleBase(t *testing.T) {
+	dirA := t.TempDir()
+	runnerA := &mockRunner{switches: map[string]bool{}}
+	if err := sync.EnsureWith(dirA, "5.2.0", runnerA); err != nil {
+		t.Fatal(err)
+	}
+	existingSwitch := runnerA.createCalled[0]
+
+	dirB := t.TempDir()
+	runner := &mockRunner{
+		switches:       map[string]bool{existingSwitch: true},
+		switchVersions: map[string]string{existingSwitch: "5.2.0"},
+		cachedSwitches: []string{existingSwitch},
+	}
+
+	if err := sync.EnsureWith(dirB, "5.3.0", runner); err != nil {
+		t.Fatalf("EnsureWith: %v", err)
+	}
+
+	if len(runner.cloneCalled) != 0 {
+		t.Errorf("expected no CloneSwitch for incompatible version, got %d", len(runner.cloneCalled))
+	}
+	if len(runner.createCalled) != 1 {
+		t.Errorf("expected CreateSwitch called once, got %d", len(runner.createCalled))
+	}
+}
+
+func TestEnsureWith_PerProjectSwitchPaths_DifferByProject(t *testing.T) {
+	runner := &mockRunner{switches: map[string]bool{}}
+
+	dirA := t.TempDir()
+	if err := sync.EnsureWith(dirA, "5.2.0", runner); err != nil {
+		t.Fatal(err)
+	}
+	runner.cachedSwitches = []string{runner.createCalled[0]}
+
+	dirB := t.TempDir()
+	if err := sync.EnsureWith(dirB, "5.2.0", runner); err != nil {
+		t.Fatal(err)
+	}
+
+	sA, _ := project.LoadState(dirA)
+	sB, _ := project.LoadState(dirB)
+	if sA.SwitchPath == sB.SwitchPath {
+		t.Error("different projects should get different switch paths")
 	}
 }


### PR DESCRIPTION
## Summary

- Switches are now per-project (keyed on `hash(projectDir + ocamlVersion)`) rather than shared per OCaml version, restoring isolation between projects
- When a project needs a new switch, `oc` scans `~/.cache/oc/switches/` for an existing compatible switch (same OCaml version) and clones it via `opam switch copy`, then installs only the delta
- Falls back gracefully to a fresh `opam switch create` if no compatible base exists or the clone fails
- Adds `CachePathForProject` and `ListCachedSwitches` to `internal/switch`; extends `OpamRunner` interface with `CloneSwitch`, `GetSwitchOCamlVersion`, `ListCachedSwitches`

## Test plan

- [x] All existing unit tests pass (`go test ./...`)
- [x] New tests cover: clone when base exists, fallback to create on clone failure, skip clone for incompatible version, per-project path isolation
- [ ] Integration test: `oc build` on a second project with same OCaml version clones rather than creates from scratch

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)